### PR TITLE
Use double-click to play selected song

### DIFF
--- a/src/list/trackslist.cpp
+++ b/src/list/trackslist.cpp
@@ -30,7 +30,7 @@ TracksList::TracksList(spt::Spotify &spotify, Settings &settings, QWidget *paren
 	// Song context menu
 	setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
 	QWidget::connect(this, &QWidget::customContextMenuRequested, this, &TracksList::menu);
-	QTreeWidget::connect(this, &QTreeWidget::itemClicked, this, &TracksList::clicked);
+	QTreeWidget::connect(this, &QTreeWidget::itemDoubleClicked, this, &TracksList::clicked);
 
 	// Songs header context menu
 	header()->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);


### PR DESCRIPTION
This allow us to actually click a song and not replace the current one.

It's also a common behaviour on most music player UIs and even on the official app