### PR TITLE
support build with Qt5 that does not have D-Bus support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find Qt
-find_package(Qt5 COMPONENTS Core Widgets Network Gui Svg DBus ${QT_QUICK_PKG} REQUIRED)
+find_package(Qt5 COMPONENTS Core Widgets Network Gui Svg ${QT_QUICK_PKG} OPTIONAL_COMPONENTS DBus)
 
 # Glob source files
 file(GLOB MAIN_SRC "src/*.[hc]pp")
@@ -71,5 +71,8 @@ target_link_libraries(spotify-qt PRIVATE
 		Qt5::Network
 		Qt5::Gui
 		Qt5::Svg
-		Qt5::DBus
 		${SPOTIFY_QT_QUICK_LIB})
+if (EXISTS "${Qt5Dbus_DIR}")
+	target_compile_definitions(spotify-qt PRIVATE WITH_DBUS)
+	target_link_libraries(spotify-qt PRIVATE Qt5::DBus)
+endif()

--- a/src/keyring/kwallet.cpp
+++ b/src/keyring/kwallet.cpp
@@ -5,20 +5,26 @@
 KWallet::KWallet(QString username)
 	: walletName(),
 	walletHandle(0),
-	username(std::move(username)),
-	dbus("org.kde.kwalletd5", "/modules/kwalletd5",
+	username(std::move(username))
+#ifdef WITH_DBUS
+	, dbus("org.kde.kwalletd5", "/modules/kwalletd5",
 		"org.kde.KWallet", QDBusConnection::sessionBus())
+#endif
 {
 	appName = QCoreApplication::applicationName();
 }
 
 bool KWallet::isEnabled()
 {
+#ifdef WITH_DBUS
 	auto call = dbus.call(QDBus::Block, "isEnabled");
 	if (call.type() != QDBusMessage::ReplyMessage)
 		return false;
 
 	return call.arguments().at(0).toBool();
+#else
+	return false;
+#endif
 }
 
 bool KWallet::unlocked() const
@@ -28,6 +34,7 @@ bool KWallet::unlocked() const
 
 bool KWallet::getWallet()
 {
+#ifdef WITH_DBUS
 	// Wallet name
 	walletName = dbus
 		.call(QDBus::Block, "localWallet")
@@ -45,6 +52,9 @@ bool KWallet::getWallet()
 		}).arguments().at(0).toInt();
 
 	return walletHandle > 0;
+#else
+	return false;
+#endif
 }
 
 bool KWallet::unlock()
@@ -60,6 +70,7 @@ bool KWallet::unlock()
 
 bool KWallet::writePassword(const QString &password)
 {
+#ifdef WITH_DBUS
 	if (!unlocked() && !unlock())
 		return false;
 
@@ -68,10 +79,14 @@ bool KWallet::writePassword(const QString &password)
 	});
 
 	return true;
+#else
+	return false;
+#endif
 }
 
 QString KWallet::readPassword()
 {
+#ifdef WITH_DBUS
 	if (!unlocked() && !unlock())
 		return QString();
 
@@ -79,4 +94,7 @@ QString KWallet::readPassword()
 		.callWithArgumentList(QDBus::Block, "readPassword", {
 			walletHandle, appName, username, appName
 		}).arguments().at(0).toString();
+#else
+	return QString();
+#endif
 }

--- a/src/keyring/kwallet.hpp
+++ b/src/keyring/kwallet.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifdef WITH_DBUS
 #include <QDBusInterface>
+#endif
 #include <QCoreApplication>
 
 class KWallet
@@ -8,7 +10,9 @@ class KWallet
 private:
 	QString walletName;
 	int walletHandle;
+#if WITH_DBUS
 	QDBusInterface dbus;
+#endif
 	QString username;
 	QString appName;
 

--- a/src/mediaplayer/mediaplayer.cpp
+++ b/src/mediaplayer/mediaplayer.cpp
@@ -1,11 +1,14 @@
 #include "mediaplayer.hpp"
 
 MediaPlayer::MediaPlayer(spt::Spotify *spotify, QObject *parent)
-	: spotify(spotify), parent(parent),
-	dBus(QDBusConnection::sessionBus()), QDBusAbstractAdaptor(parent)
+	: spotify(spotify), parent(parent)
+#ifdef WITH_DBUS
+	, dBus(QDBusConnection::sessionBus()), QDBusAbstractAdaptor(parent)
+#endif
 {
 }
 
+#ifdef WITH_DBUS
 void MediaPlayer::Quit() const
 {
 	QCoreApplication::quit();
@@ -16,6 +19,7 @@ void MediaPlayer::Raise() const
 	if (parent != nullptr)
 		((QWidget *) parent)->raise();
 }
+#endif
 
 bool MediaPlayer::canQuit() const
 {

--- a/src/mediaplayer/mediaplayer.hpp
+++ b/src/mediaplayer/mediaplayer.hpp
@@ -6,14 +6,21 @@ class MediaPlayer;
 #include "mediaplayerplayer.hpp"
 
 #include <QCoreApplication>
+#ifdef WITH_DBUS
 #include <QDBusAbstractAdaptor>
 #include <QDBusConnection>
 #include <QDBusError>
 #include <QDBusInterface>
+#endif
 #include <QDebug>
 #include <QStringList>
 
-class MediaPlayer: public QDBusAbstractAdaptor
+class MediaPlayer: public
+#ifdef WITH_DBUS
+QDBusAbstractAdaptor
+#else
+QObject
+#endif
 {
 Q_OBJECT
 
@@ -37,11 +44,15 @@ public:
 	QStringList supportedMimeTypes() const;
 
 public slots:
+#ifdef WITH_DBUS
 	Q_NOREPLY void Quit() const;
 	Q_NOREPLY void Raise() const;
+#endif
 
 private:
+#ifdef WITH_DBUS
 	QDBusConnection dBus;
+#endif
 	spt::Spotify *spotify;
 	QObject *parent;
 };

--- a/src/mediaplayer/mediaplayerplayer.cpp
+++ b/src/mediaplayer/mediaplayerplayer.cpp
@@ -3,7 +3,10 @@
 using namespace mp;
 
 MediaPlayerPlayer::MediaPlayerPlayer(spt::Spotify *spotify, QObject *parent)
-	: spotify(spotify), dBus(QDBusConnection::sessionBus()), QDBusAbstractAdaptor(parent)
+	: spotify(spotify)
+#ifdef WITH_DBUS
+	, dBus(QDBusConnection::sessionBus()), QDBusAbstractAdaptor(parent)
+#endif
 {
 }
 
@@ -40,10 +43,12 @@ void MediaPlayerPlayer::Seek(qint64 offset) const
 	spotify->seek(offset);
 }
 
+#ifdef WITH_DBUS
 void MediaPlayerPlayer::SetPosition(const QDBusObjectPath &trackId, qint64 position) const
 {
 	spotify->seek(position);
 }
+#endif
 
 void MediaPlayerPlayer::Stop() const
 {

--- a/src/mediaplayer/mediaplayerplayer.hpp
+++ b/src/mediaplayer/mediaplayerplayer.hpp
@@ -10,16 +10,21 @@ namespace mp
 #include "service.hpp"
 
 #include <QCoreApplication>
+#ifdef WITH_DBUS
 #include <QDBusAbstractAdaptor>
 #include <QDBusConnection>
 #include <QDBusError>
 #include <QDBusInterface>
+#endif
 #include <QDebug>
 #include <QVariantMap>
 
 namespace mp
 {
-	class MediaPlayerPlayer: public QDBusAbstractAdaptor
+	class MediaPlayerPlayer : QObject
+#ifdef WITH_DBUS
+	: public QDBusAbstractAdaptor
+#endif
 	{
 	Q_OBJECT
 
@@ -80,11 +85,15 @@ namespace mp
 		void Stop() const;
 		void Play() const;
 		void Seek(qint64 offset) const;
+#ifdef WITH_DBUS
 		void SetPosition(const QDBusObjectPath &trackId, qint64 position) const;
+#endif
 		void OpenUri(QString uri) const;
 
 	private:
+#ifdef WITH_DBUS
 		QDBusConnection dBus;
+#endif
 		spt::Spotify *spotify;
 
 		spt::Playback currentPlayback() const;

--- a/src/mediaplayer/service.cpp
+++ b/src/mediaplayer/service.cpp
@@ -8,21 +8,26 @@ using namespace mp;
 Service::Service(spt::Spotify *spotify, QObject *parent)
 	: spotify(spotify), playerPlayer(nullptr), QObject(parent)
 {
+#ifdef WITH_DBUS
 	if (!QDBusConnection::sessionBus().registerService(SERVICE_NAME))
 	{
 		qWarning() << "warning: failed to register d-bus service, is another instance running?";
 		return;
 	}
+#endif
 	new MediaPlayer(spotify, this);
 	playerPlayer = new MediaPlayerPlayer(spotify, this);
+#ifdef WITH_DBIS
 	if (!QDBusConnection::sessionBus().registerObject(SERVICE_PATH, this, QDBusConnection::ExportAdaptors))
 		qWarning() << "warning: failed to register d-bus object";
+#endif
 }
 
 Service::~Service() = default;
 
 void Service::signalPropertiesChange(const QObject *adaptor, const QVariantMap &properties)
 {
+#ifdef WITH_DBUS
 	QDBusMessage msg = QDBusMessage::createSignal("/org/mpris/MediaPlayer2",
 		"org.freedesktop.DBus.Properties", "PropertiesChanged");
 
@@ -31,6 +36,7 @@ void Service::signalPropertiesChange(const QObject *adaptor, const QVariantMap &
 	msg << QStringList();
 
 	QDBusConnection::sessionBus().send(msg);
+#endif
 }
 
 void Service::metadataChanged()

--- a/src/mediaplayer/service.hpp
+++ b/src/mediaplayer/service.hpp
@@ -9,7 +9,9 @@ namespace mp
 #include "mediaplayer.hpp"
 #include "mediaplayerplayer.hpp"
 
+#ifdef WITH_DBUS
 #include <QDBusContext>
+#endif
 
 namespace mp
 {


### PR DESCRIPTION
Hi!

Qt5 can be built without D-Bus support. It would be nice if this configuration was supported by spotify-qt as I don't have D-Bus installed on my system. I have attached a proof-of-concept fix to this pull request. You probably don't want to merge it as-is as I have not tested it with D-Bus present, but hopefully it can serve as a starting point.