### PR TITLE
Added a command-line option for resetting Spotify credentials

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,8 @@ int main(int argc, char *argv[])
 	parser.addVersionOption();
 	parser.addHelpOption();
 	parser.addOptions({
-		{"debug", "Enable debug menu for troubleshooting issues."}
+		{"debug", "Enable debug menu for troubleshooting issues."},
+		{"reset-credentials", "Allows providing new Spotify credentials."}
 	});
 	parser.process(app);
 
@@ -44,7 +45,7 @@ int main(int argc, char *argv[])
 		MainMenu::showDebugMenu = true;
 
 	// First setup window
-	if (settings.account.refreshToken.isEmpty())
+	if (settings.account.refreshToken.isEmpty() || parser.isSet("reset-credentials"))
 	{
 #ifdef USE_QT_QUICK
 		if (qml.setup())


### PR DESCRIPTION
If Spotify app secret is reset it leaves spotify-qt in an unusable state, failing with `Failed to refresh token: Invalid client` on startup.
This PR allows for changing the Spotify credentials using a command-line option. It is also useful if one wants to use a different app or a different account.