### PR TITLE
Fix pixelated icons with HiDPI scaling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@ int main(int argc, char *argv[])
 
 	// Create Qt application
 	QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+	QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 	QApplication app(argc, argv);
 
 	// Settings


### PR DESCRIPTION
This fixes pixelated icons throughout spotify-qt's interface for me with Plasma's global scaling setting.