### PR TITLE
Don’t force size on startup

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -60,7 +60,6 @@ MainWindow::MainWindow(lib::settings &settings)
 	// Setup main window
 	setWindowTitle("spotify-qt");
 	setWindowIcon(Icon::get("logo:spotify-qt"));
-	resize(1280, 720);
 	setCentralWidget(createCentralWidget());
 	toolBar = new MainToolBar(*spotify, settings, this);
 	addToolBar(Qt::ToolBarArea::TopToolBarArea, toolBar);


### PR DESCRIPTION
Desktop environments restore the window size on startup, and setSize() breaks that feature.

If the window is too small on first start, we need to use layout size constraints instead.