### PR TITLE
add openSUSE Tumbleweed package to readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ free to, just please open an issue, or get in contact with me, so I can add it t
 | DragonflyBSD | [![DPorts](https://repology.org/badge/version-for-repo/dports/spotify-qt.svg?header=DPorts)](https://github.com/DragonFlyBSD/DPorts/blob/master/audio/spotify-qt/Makefile) | [ehaupt](https://github.com/ehaupt) |
 | Void Linux | [![Void Linux](https://repology.org/badge/version-for-repo/void_x86_64/spotify-qt.svg?header=Void%20Linux)](https://github.com/void-linux/void-packages/blob/master/srcpkgs/spotify-qt/template) | [abenson](https://github.com/abenson) |
 | nixpkgs | [![nixpkgs unstable](https://repology.org/badge/version-for-repo/nix_unstable/spotify-qt.svg?header=nixpkgs%20unstable)](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/audio/spotify-qt/default.nix) | [karthikiyengar](https://github.com/karthikiyengar)
+| openSUSE Tumbleweed | [![openSUSE Multimedia:Apps Tumbleweed package](https://repology.org/badge/version-for-repo/opensuse_multimedia_apps_tumbleweed/spotify-qt.svg)](https://software.opensuse.org//download.html?project=multimedia%3Aapps&package=spotify-qt) | [KaratekHD](https://github.com/KaratekHD)
 | Other (Linux) | [![Snapcraft](https://snapcraft.io//spotify-qt/badge.svg)](https://snapcraft.io/spotify-qt) | [kraxarn](https://github.com/kraxarn) |
 
 The snap version can be installed by simply running  `snap install spotify-qt`, 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ free to, just please open an issue, or get in contact with me, so I can add it t
 | DragonflyBSD | [![DPorts](https://repology.org/badge/version-for-repo/dports/spotify-qt.svg?header=DPorts)](https://github.com/DragonFlyBSD/DPorts/blob/master/audio/spotify-qt/Makefile) | [ehaupt](https://github.com/ehaupt) |
 | Void Linux | [![Void Linux](https://repology.org/badge/version-for-repo/void_x86_64/spotify-qt.svg?header=Void%20Linux)](https://github.com/void-linux/void-packages/blob/master/srcpkgs/spotify-qt/template) | [abenson](https://github.com/abenson) |
 | nixpkgs | [![nixpkgs unstable](https://repology.org/badge/version-for-repo/nix_unstable/spotify-qt.svg?header=nixpkgs%20unstable)](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/audio/spotify-qt/default.nix) | [karthikiyengar](https://github.com/karthikiyengar)
-| openSUSE Tumbleweed | [![openSUSE Multimedia:Apps Tumbleweed package](https://repology.org/badge/version-for-repo/opensuse_multimedia_apps_tumbleweed/spotify-qt.svg)](https://software.opensuse.org//download.html?project=multimedia%3Aapps&package=spotify-qt) | [KaratekHD](https://github.com/KaratekHD)
+| openSUSE | [![openSUSE Multimedia:Apps Tumbleweed package](https://repology.org/badge/version-for-repo/opensuse_multimedia_apps_tumbleweed/spotify-qt.svg?header=openSUSE)](https://software.opensuse.org//download.html?project=multimedia%3Aapps&package=spotify-qt) | [KaratekHD](https://github.com/KaratekHD)
 | Other (Linux) | [![Snapcraft](https://snapcraft.io//spotify-qt/badge.svg)](https://snapcraft.io/spotify-qt) | [kraxarn](https://github.com/kraxarn) |
 
 The snap version can be installed by simply running  `snap install spotify-qt`, 


### PR DESCRIPTION
So I added the package I built for openSUSE Tumbleweed to the list of available packages. 
It is also available for openSUSE Leap 15.2 and the Release Candidate for 15.3,  however repology.org doesn't generate badges for these repos (the package is part of the [multimedia:apps](https://build.opensuse.org/project/show/multimedia:apps) factory project and not of the main repos) so I did not add them to the list.