### PR TITLE
Add model to TrackList

### DIFF
--- a/lib/include/lib/format.hpp
+++ b/lib/include/lib/format.hpp
@@ -21,7 +21,7 @@ namespace lib
 		 * @return string
 		 */
 		template<typename Format>
-		static std::string format(const Format &fmt)
+		static auto format(const Format &fmt) -> std::string
 		{
 			return fmt;
 		}
@@ -34,7 +34,7 @@ namespace lib
 		 * @return Formatted string
 		 */
 		template<typename Format, typename Arg, typename... Args>
-		static std::string format(const Format &fmt, const Arg &arg, Args &&... args)
+		static auto format(const Format &fmt, const Arg &arg, Args &&... args) -> std::string
 		{
 			return format(collect(fmt, arg), args...);
 		}
@@ -43,13 +43,13 @@ namespace lib
 		 * Format time as M:SS
 		 * @param ms Milliseconds
 		 */
-		static std::string time(int ms);
+		static auto time(int ms) -> std::string;
 
 		/**
 		 * Format size as B, kB, MB or GB (bytes)
 		 * @param bytes Bytes
 		 */
-		static std::string size(unsigned int bytes);
+		static auto size(unsigned int bytes) -> std::string;
 
 		/**
 		 * Format as k or M
@@ -72,7 +72,7 @@ namespace lib
 		 * @return Formatted string
 		 */
 		template<typename Format>
-		static std::string collect(const Format &fmt, const std::string &arg)
+		static auto collect(const Format &fmt, const std::string &arg) -> std::string
 		{
 			auto str = std::string(fmt);
 			auto index = str.find("{}");
@@ -89,7 +89,7 @@ namespace lib
 		 * @return Formatted string
 		 */
 		template<typename Format, typename Arg>
-		static std::string collect(const Format &fmt, const Arg &arg)
+		static auto collect(const Format &fmt, const Arg &arg) -> std::string
 		{
 			return collect(fmt, std::to_string(arg));
 		}
@@ -101,7 +101,7 @@ namespace lib
 		 * @return Formatted string
 		 */
 		template<typename Format>
-		static std::string collect(const Format &fmt, const char *arg)
+		static auto collect(const Format &fmt, const char *arg) -> std::string
 		{
 			return collect(fmt, std::string(arg));
 		}
@@ -113,7 +113,7 @@ namespace lib
 		 * @return Formatted string
 		 */
 		template<typename Format>
-		static std::string collect(const Format &fmt, bool arg)
+		static auto collect(const Format &fmt, bool arg) -> std::string
 		{
 			return collect(fmt, arg ? "true" : "false");
 		}
@@ -125,7 +125,7 @@ namespace lib
 		 * @return Formatted string
 		 */
 		template<typename Format>
-		static std::string collect(const Format &fmt, const nlohmann::json &arg)
+		static auto collect(const Format &fmt, const nlohmann::json &arg) -> std::string
 		{
 			return collect(fmt, arg.dump());
 		}

--- a/lib/include/lib/format.hpp
+++ b/lib/include/lib/format.hpp
@@ -46,6 +46,13 @@ namespace lib
 		static auto time(int ms) -> std::string;
 
 		/**
+		 * Get minutes and seconds from milliseconds
+		 * @param ms Milliseconds
+		 * @return Pair as <minutes, seconds>
+		 */
+		static auto time_min_sec(int ms) -> std::pair<int, int>;
+
+		/**
 		 * Format size as B, kB, MB or GB (bytes)
 		 * @param bytes Bytes
 		 */

--- a/lib/include/lib/format.hpp
+++ b/lib/include/lib/format.hpp
@@ -58,6 +58,13 @@ namespace lib
 		static auto count(unsigned int count) -> std::string;
 
 	private:
+		/** Kilo (1 000) */
+		static constexpr unsigned int size_k = 1000;
+		/** Mega (1 000 000) */
+		static constexpr unsigned int size_m = size_k * 1000;
+		/** Giga (1 000 000 000) */
+		static constexpr unsigned int size_g = size_m * 1000;
+
 		/**
 		 * Format string into another string
 		 * @param fmt String with {} to replace

--- a/lib/src/format.cpp
+++ b/lib/src/format.cpp
@@ -2,9 +2,9 @@
 
 using namespace lib;
 
-std::string fmt::time(int ms)
+auto fmt::time(int ms) -> std::string
 {
-	auto seconds = ms / 1000;
+	auto seconds = ms / size_k;
 
 	auto m = seconds / 60;
 	auto s = seconds % 60;
@@ -13,30 +13,36 @@ std::string fmt::time(int ms)
 		format("{}{}", s < 10 ? "0" : "", s % 60));
 }
 
-std::string fmt::size(unsigned int bytes)
+auto fmt::size(unsigned int bytes) -> std::string
 {
-	if (bytes >= 1000000000)
-		return format("{} GB", bytes / 1000000000);
+	if (bytes >= size_g)
+	{
+		return format("{} GB", bytes / size_g);
+	}
 
-	if (bytes >= 1000000)
-		return format("{} MB", bytes / 1000000);
+	if (bytes >= size_m)
+	{
+		return format("{} MB", bytes / size_m);
+	}
 
-	if (bytes >= 1000)
-		return format("{} kB", bytes / 1000);
+	if (bytes >= size_k)
+	{
+		return format("{} kB", bytes / size_k);
+	}
 
 	return format("{} B", bytes);
 }
 
 auto fmt::count(unsigned int count) -> std::string
 {
-	if (count >= 1000000)
+	if (count >= size_m)
 	{
-		return format("{}M", count / 1000000);
+		return format("{}M", count / size_m);
 	}
 
-	if (count >= 1000)
+	if (count >= size_k)
 	{
-		return format("{}k", count / 1000);
+		return format("{}k", count / size_k);
 	}
 
 	return format("{}", count);

--- a/lib/src/format.cpp
+++ b/lib/src/format.cpp
@@ -4,13 +4,21 @@ using namespace lib;
 
 auto fmt::time(int ms) -> std::string
 {
-	auto seconds = ms / size_k;
-
-	auto m = seconds / 60;
-	auto s = seconds % 60;
+	auto t = time_min_sec(ms);
+	auto m = t.first;
+	auto s = t.second;
 
 	return format("{}:{}", m,
 		format("{}{}", s < 10 ? "0" : "", s % 60));
+}
+
+auto fmt::time_min_sec(int ms) -> std::pair<int, int>
+{
+	auto seconds = ms / size_k;
+	return {
+		seconds / 60,
+		seconds % 60,
+	}
 }
 
 auto fmt::size(unsigned int bytes) -> std::string

--- a/lib/src/format.cpp
+++ b/lib/src/format.cpp
@@ -18,7 +18,7 @@ auto fmt::time_min_sec(int ms) -> std::pair<int, int>
 	return {
 		seconds / 60,
 		seconds % 60,
-	}
+	};
 }
 
 auto fmt::size(unsigned int bytes) -> std::string

--- a/src/list/tracklistitem.cpp
+++ b/src/list/tracklistitem.cpp
@@ -1,90 +1,82 @@
 #include "tracklistitem.hpp"
 
-TrackListItem::TrackListItem(const QStringList &strings,
-	const lib::spt::track &track,
-	const QIcon &icon,
-	int index)
-	: QTreeWidgetItem(strings)
+TrackListItem::TrackListItem(const lib::spt::track &track,
+	const QIcon &icon, int index)
+	: track(track),
+	index(index),
+	icon(icon)
 {
-	setIcon(0, icon);
-
-	auto addedAt = QDateTime::fromString(QString::fromStdString(track.added_at),
-		Qt::DateFormat::ISODate);
-
-	setData(0, RoleTrack, QVariant::fromValue(track));
-	setData(0, RoleIndex, index);
-	setData(0, RoleAddedDate, addedAt);
-	setData(0, RoleLength, track.duration);
-
-	if (track.is_local || !track.is_playable)
-	{
-		setDisabled(true);
-		setToolTip(1, track.is_local
-			? "Local track"
-			: "Unavailable");
-	}
-
-	// Artist
-	auto names = lib::spt::entity::combine_names(track.artists, "\n");
-	setToolTip(2, QString::fromStdString(names));
-
-	// Title, album
-	for (auto i = 1; i < strings.length() - 2; i++)
-	{
-		if (toolTip(i).isEmpty())
-		{
-			setToolTip(i, strings.at(i));
-		}
-	}
-
-	// Length
-	auto length = strings.at(strings.length() - 2).split(':');
-	if (length.length() >= 2)
-	{
-		setToolTip(strings.length() - 2,
-			QString("%1m %2s (%3s total)")
-				.arg(length.at(0), length.at(1))
-				.arg(track.duration / 1000));
-	}
-
-	// Added
-	if (!DateUtils::isEmpty(addedAt))
-	{
-		setToolTip(strings.length() - 1,
-			QLocale().toString(addedAt.date()));
-	}
 }
 
-auto TrackListItem::operator<(const QTreeWidgetItem &item) const -> bool
+TrackListItem::TrackListItem(const lib::spt::track &track, int index)
+	: TrackListItem(track, emptyIcon(), index)
 {
-	auto column = treeWidget()->sortColumn();
-
-	// Track number
-	if (column == 0)
-	{
-		return data(0, RoleIndex).toInt() < item.data(0, RoleIndex).toInt();
-	}
-
-	// Length
-	if (column == 4)
-	{
-		return data(0, RoleLength).toInt() < item.data(0, RoleLength).toInt();
-	}
-
-	// Added
-	if (column == 5)
-	{
-		return data(0, RoleAddedDate).toDateTime() < item.data(0, RoleAddedDate).toDateTime();
-	}
-
-	return removePrefix(text(column))
-		.compare(removePrefix(item.text(column)),
-			Qt::CaseInsensitive) < 0;
 }
+
+//auto TrackListItem::operator<(const QTreeWidgetItem &item) const -> bool
+//{
+//	auto column = treeWidget()->sortColumn();
+//
+//	// Track number
+//	if (column == 0)
+//	{
+//		return data(0, RoleIndex).toInt() < item.data(0, RoleIndex).toInt();
+//	}
+//
+//	// Length
+//	if (column == 4)
+//	{
+//		return data(0, RoleLength).toInt() < item.data(0, RoleLength).toInt();
+//	}
+//
+//	// Added
+//	if (column == 5)
+//	{
+//		return data(0, RoleAddedDate).toDateTime() < item.data(0, RoleAddedDate).toDateTime();
+//	}
+//
+//	return removePrefix(text(column))
+//		.compare(removePrefix(item.text(column)),
+//			Qt::CaseInsensitive) < 0;
+//}
 
 auto TrackListItem::removePrefix(const QString &str) -> QString
 {
 	return str.startsWith("The ", Qt::CaseInsensitive)
 		? str.right(str.length() - 4)
 		: str;
+}
+
+auto TrackListItem::addedAt() const -> QDateTime
+{
+	auto date = QString::fromStdString(track.added_at);
+	return QDateTime::fromString(date, Qt::DateFormat::ISODate);
+}
+
+auto TrackListItem::isDisabled() const -> bool
+{
+	return track.is_local || !track.is_playable;
+}
+
+auto TrackListItem::emptyIcon() -> QIcon
+{
+	constexpr int emptyPixmapSize = 64;
+	QPixmap emptyPixmap(emptyPixmapSize, emptyPixmapSize);
+	emptyPixmap.fill(Qt::transparent);
+	return QIcon(emptyPixmap);
+}
+
+auto TrackListItem::getTrack() const -> const lib::spt::track &
+{
+	return track;
+}
+
+auto TrackListItem::getIndex() const -> int
+{
+	return index;
+}
+
+auto TrackListItem::operator==(const lib::spt::track &item) const -> bool
+{
+	return item.id == track.id;
 }

--- a/src/list/tracklistitem.cpp
+++ b/src/list/tracklistitem.cpp
@@ -58,6 +58,11 @@ auto TrackListItem::isDisabled() const -> bool
 	return track.is_local || !track.is_playable;
 }
 
+auto TrackListItem::isValid() const -> bool
+{
+	return track.is_valid();
+}
+
 auto TrackListItem::emptyIcon() -> QIcon
 {
 	constexpr int emptyPixmapSize = 64;

--- a/src/list/tracklistitem.hpp
+++ b/src/list/tracklistitem.hpp
@@ -22,6 +22,9 @@ public:
 	/** If track can't be played */
 	auto isDisabled() const -> bool;
 
+	/** Track is valid */
+	auto isValid() const -> bool;
+
 	/** Get the underlying track */
 	auto getTrack() const -> const lib::spt::track &;
 

--- a/src/list/tracklistitem.hpp
+++ b/src/list/tracklistitem.hpp
@@ -1,23 +1,44 @@
 #pragma once
 
-#include "enum/datarole.hpp"
 #include "lib/spotify/track.hpp"
-#include "util/dateutils.hpp"
-#include "util/utils.hpp"
-#include "lib/settings.hpp"
-#include "lib/spotify/entity.hpp"
-#include "metatypes.hpp"
+#include "role/tracklistcolumn.hpp"
 
-#include <QTreeWidgetItem>
+#include <QIcon>
+#include <QDateTime>
 
-class TrackListItem: public QTreeWidgetItem
+class TrackListItem
 {
 public:
-	TrackListItem(const QStringList &strings, const lib::spt::track &track, const QIcon &icon,
-		int index);
+	/** New track list item */
+	TrackListItem(const lib::spt::track &track,
+		const QIcon &icon, int index);
+
+	/** New track list item with default icon */
+	TrackListItem(const lib::spt::track &track, int index);
+
+	/** QDateTime representation of track.added_at */
+	auto addedAt() const -> QDateTime;
+
+	/** If track can't be played */
+	auto isDisabled() const -> bool;
+
+	/** Get the underlying track */
+	auto getTrack() const -> const lib::spt::track &;
+
+	/** Get index of track in context */
+	auto getIndex() const -> int;
+
+	/** Track's ID match */
+	auto operator==(const lib::spt::track &track) const -> bool;
 
 private:
-	auto operator<(const QTreeWidgetItem &item) const -> bool override;
+	lib::spt::track track;
+	int index = -1;
+	QIcon icon;
 
+	/** Remove "The" prefix if present */
 	static auto removePrefix(const QString &str) -> QString;
+
+	/** Empty placeholder icon */
+	static auto emptyIcon() -> QIcon;
 };

--- a/src/list/trackslist.cpp
+++ b/src/list/trackslist.cpp
@@ -58,9 +58,7 @@ void TracksList::menu(const QPoint &pos)
 		return;
 	}
 
-	//auto index = item->data(0, RoleIndex).toInt();
-	auto *songMenu = new SongMenu(trackItem.getTrack(), spotify,
-		trackItem.getIndex(), parentWidget());
+	auto *songMenu = new SongMenu(trackItem, spotify, parentWidget());
 	songMenu->popup(mapToGlobal(pos));
 }
 

--- a/src/list/trackslist.cpp
+++ b/src/list/trackslist.cpp
@@ -52,14 +52,15 @@ TracksList::TracksList(spt::Spotify &spotify, lib::settings &settings, lib::cach
 void TracksList::menu(const QPoint &pos)
 {
 	auto index = indexAt(pos);
-	const auto &track = model.at(index.row());
-	if (!track.is_valid())
+	const auto &trackItem = model.at(index.row());
+	if (!trackItem.isValid())
 	{
 		return;
 	}
 
 	//auto index = item->data(0, RoleIndex).toInt();
-	auto *songMenu = new SongMenu(track, spotify, index.row(), parentWidget());
+	auto *songMenu = new SongMenu(trackItem.getTrack(), spotify,
+		trackItem.getIndex(), parentWidget());
 	songMenu->popup(mapToGlobal(pos));
 }
 

--- a/src/list/trackslist.hpp
+++ b/src/list/trackslist.hpp
@@ -1,15 +1,16 @@
 #pragma once
 
-#include "../spotify/spotify.hpp"
+#include "spotify/spotify.hpp"
 #include "lib/cache.hpp"
-#include "../spotify/current.hpp"
-#include "../menu/songmenu.hpp"
+#include "spotify/current.hpp"
+#include "menu/songmenu.hpp"
 #include "lib/set.hpp"
+#include "model/tracklistmodel.hpp"
 
 #include <QListWidget>
 #include <QTreeWidgetItem>
 
-class TracksList: public QTreeWidget
+class TracksList: public QTreeView
 {
 Q_OBJECT
 
@@ -43,6 +44,16 @@ public:
 	 */
 	void load(const lib::spt::album &album, const std::string &trackId = std::string());
 
+	/**
+	 * Get IDs of all tracks currently shown
+	 */
+	auto trackIds() const -> std::vector<std::string>;
+
+	/**
+	 * Remove specified track from list
+	 */
+	void remove(lib::spt::track &track);
+
 protected:
 	void resizeEvent(QResizeEvent *event) override;
 
@@ -71,4 +82,6 @@ private:
 	// qt
 	QTreeWidgetItem *playingTrackItem = nullptr;
 	QIcon emptyIcon;
+
+	TrackListModel model;
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -408,21 +408,7 @@ void MainWindow::openArtist(const std::string &artistId)
 
 auto MainWindow::currentTracks() -> std::vector<std::string>
 {
-	std::vector<std::string> tracks;
-	tracks.reserve(songs->topLevelItemCount());
-
-	for (int i = 0; i < songs->topLevelItemCount(); i++)
-	{
-		auto track = songs->topLevelItem(i)->data(0, RoleTrack)
-			.value<lib::spt::track>();
-		if (!track.is_valid())
-		{
-			continue;
-		}
-		tracks.push_back(lib::spt::api::to_uri("track", track.id));
-	}
-
-	return tracks;
+	return songs->trackIds();
 }
 
 void MainWindow::reloadTrayIcon()
@@ -445,13 +431,14 @@ void MainWindow::setFixedWidthTime(bool value)
 
 void MainWindow::toggleTrackNumbers(bool enabled)
 {
-	for (int i = 0; i < songs->topLevelItemCount(); i++)
-	{
-		auto *item = songs->topLevelItem(i);
-		item->setText(0, enabled
-			? QString("%1").arg(item->data(0, RoleIndex).toInt() + 1, 3)
-			: QString());
-	}
+	// TODO
+//	for (int i = 0; i < songs->topLevelItemCount(); i++)
+//	{
+//		auto *item = songs->topLevelItem(i);
+//		item->setText(0, enabled
+//			? QString("%1").arg(item->data(0, RoleIndex).toInt() + 1, 3)
+//			: QString());
+//	}
 }
 
 //region Getters

--- a/src/menu/songmenu.cpp
+++ b/src/menu/songmenu.cpp
@@ -229,29 +229,9 @@ void SongMenu::remFromPlaylist(bool /*checked*/)
 			}
 
 			// Remove from interface
-			QTreeWidgetItem *item = nullptr;
-			int i;
-			for (i = 0; i < mainWindow->getSongsTree()->topLevelItemCount(); i++)
-			{
-				item = mainWindow->getSongsTree()->topLevelItem(i);
-				if (item->data(0, RoleTrack).value<lib::spt::track>().id == track.id)
-				{
-					break;
-				}
-				item = nullptr;
-			}
-
-			if (item == nullptr)
-			{
-				mainWindow->setStatus("Failed to remove track, not found in playlist", true);
-				return;
-			}
-
-			// i doesn't necessarily match item index depending on sorting order
-			mainWindow->getSongsTree()->takeTopLevelItem(i);
+			mainWindow->getSongsTree()->remove(track);
 			mainWindow->status(lib::fmt::format("Removed {} - {} from \"{}\"",
-				track.name,
-				lib::spt::entity::combine_names(track.artists),
+				track.name, lib::spt::entity::combine_names(track.artists),
 				currentPlaylist->name));
 		});
 }

--- a/src/menu/songmenu.cpp
+++ b/src/menu/songmenu.cpp
@@ -13,9 +13,8 @@ SongMenu::SongMenu(const lib::spt::track &track, spt::Spotify &spotify,
 {
 }
 
-SongMenu::SongMenu(const lib::spt::track &track, spt::Spotify &spotify,
-	int index, QWidget *parent)
-	: SongMenu(track, spotify, nullptr, index, parent)
+SongMenu::SongMenu(const TrackListItem &track, spt::Spotify &spotify, QWidget *parent)
+	: SongMenu(track.getTrack(), spotify, nullptr, track.getIndex(), parent)
 {
 }
 

--- a/src/menu/songmenu.hpp
+++ b/src/menu/songmenu.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "../spotify/spotify.hpp"
-#include "../util/icon.hpp"
+#include "spotify/spotify.hpp"
+#include "util/icon.hpp"
 #include "lib/strings.hpp"
 #include "enum/datarole.hpp"
+#include "list/tracklistitem.hpp"
 
 #include <utility>
 
@@ -27,10 +28,9 @@ public:
 		const lib::spt::artist *fromArtist, QWidget *parent);
 
 	/**
-	 * SongMenu from playlist with index of track in playlist
+	 * SongMenu from tracks list
 	 */
-	SongMenu(const lib::spt::track &track, spt::Spotify &spotify,
-		int index, QWidget *parent);
+	SongMenu(const TrackListItem &track, spt::Spotify &spotify, QWidget *parent);
 
 private:
 	SongMenu(const lib::spt::track &track, spt::Spotify &spotify,

--- a/src/model/tracklistmodel.cpp
+++ b/src/model/tracklistmodel.cpp
@@ -4,6 +4,12 @@ TrackListModel::TrackListModel(const lib::settings &settings, QObject *parent)
 	: settings(settings),
 	QAbstractListModel(parent)
 {
+	constexpr int emptyPixmapSize = 64;
+
+	// Empty icon used as replacement for play icon
+	QPixmap emptyPixmap(emptyPixmapSize, emptyPixmapSize);
+	emptyPixmap.fill(Qt::transparent);
+	emptyIcon = QIcon(emptyPixmap);
 }
 
 void TrackListModel::add(const std::vector<lib::spt::track> &items)
@@ -75,6 +81,9 @@ auto TrackListModel::data(const QModelIndex &index, int role) const -> QVariant
 	{
 		case Qt::DisplayRole:
 			return displayRole(col, row);
+
+		case Qt::DecorationRole:
+			return emptyIcon;
 
 		case TrackRoleTrack:
 			return QVariant::fromValue(track);

--- a/src/model/tracklistmodel.cpp
+++ b/src/model/tracklistmodel.cpp
@@ -156,9 +156,9 @@ auto TrackListModel::headerData(int section, Qt::Orientation orientation,
 	}
 }
 
-auto TrackListModel::at(int index) -> const lib::spt::track &
+auto TrackListModel::at(int index) -> const TrackListItem &
 {
-	return tracks.at(index).getTrack();
+	return tracks.at(index);
 }
 
 auto TrackListModel::displayRole(TrackListColumn column, int row) const -> QString

--- a/src/model/tracklistmodel.cpp
+++ b/src/model/tracklistmodel.cpp
@@ -1,7 +1,8 @@
 #include "tracklistmodel.hpp"
 
-TrackListModel::TrackListModel(QObject *parent)
-	: QAbstractListModel(parent)
+TrackListModel::TrackListModel(const lib::settings &settings, QObject *parent)
+	: settings(settings),
+	QAbstractListModel(parent)
 {
 }
 
@@ -11,6 +12,27 @@ void TrackListModel::add(const std::vector<lib::spt::track> &items)
 		static_cast<int>(rowCount() + tracks.size() - 1));
 	lib::vector::append(tracks, items);
 	endInsertRows();
+}
+
+void TrackListModel::remove(lib::spt::track &item)
+{
+	std::vector<lib::spt::track>::iterator iter;
+	for (iter = tracks.begin(); iter != tracks.end(); iter++)
+	{
+		if (iter->id == item.id)
+		{
+			break;
+		}
+	}
+
+	if (iter == tracks.end())
+	{
+		return;
+	}
+	auto index = static_cast<int>(std::distance(tracks.begin(), iter));
+	beginRemoveRows(QModelIndex(), index, index);
+	tracks.erase(iter);
+	endRemoveRows();
 }
 
 void TrackListModel::clear()
@@ -39,21 +61,30 @@ auto TrackListModel::columnCount(const QModelIndex &/*parent*/) const -> int
 
 auto TrackListModel::data(const QModelIndex &index, int role) const -> QVariant
 {
-	if (index.row() < 0 || index.row() >= tracks.size())
+	auto row = index.row();
+	auto col = static_cast<TrackListColumn>(index.column());
+
+	if (row < 0 || row >= tracks.size())
 	{
 		return QVariant();
 	}
 
-	switch (static_cast<TrackListRole>(role))
+	const auto &track = tracks.at(row);
+
+	switch (role)
 	{
-		case TrackListRole::Track:
-			return QVariant::fromValue(tracks.at(index.row()));
+		case Qt::DisplayRole:
+			return displayRole(col, row);
 
-		case TrackListRole::Index:
+		case TrackRoleTrack:
+			return QVariant::fromValue(track);
+
+		case TrackRoleIndex:
 			return index.row();
-	}
 
-	return QVariant();
+		default:
+			return QVariant();
+	}
 }
 
 auto TrackListModel::data(const QModelIndex &index) const -> QVariant
@@ -64,12 +95,118 @@ auto TrackListModel::data(const QModelIndex &index) const -> QVariant
 auto TrackListModel::roleNames() const -> QHash<int, QByteArray>
 {
 	return {
-		{static_cast<int>(TrackListRole::Track), "track"},
-		{static_cast<int>(TrackListRole::Index), "index"},
+		{TrackRoleTrack, "track"},
+		{TrackRoleIndex, "index"},
 	};
 }
 
-auto TrackListModel::parent(const QModelIndex &/*child*/) const -> QModelIndex
+auto TrackListModel::headerData(int section, Qt::Orientation orientation,
+	int role) const -> QVariant
 {
-	return {};
+	if (role != Qt::DisplayRole || orientation != Qt::Horizontal)
+	{
+		return QVariant();
+	}
+
+	switch (static_cast<TrackListColumn>(section))
+	{
+		case TrackListColumn::Number:
+			return settings.general.track_numbers == lib::context_all
+				? QString("#")
+				: QString();
+
+		case TrackListColumn::Name:
+			return QString("Title");
+
+		case TrackListColumn::Artists:
+			return QString("Artist");
+
+		case TrackListColumn::Album:
+			return QString("Album");
+
+		case TrackListColumn::Duration:
+			return QString("Length");
+
+		case TrackListColumn::AddedAt:
+			return QString("Added");
+
+		default:
+			return QVariant();
+	}
+}
+
+auto TrackListModel::at(int index) -> const lib::spt::track &
+{
+	return tracks.at(index);
+}
+
+auto TrackListModel::displayRole(TrackListColumn column, int row) const -> QString
+{
+	const auto &track = tracks.at(row);
+
+	if (column == TrackListColumn::Number)
+	{
+		// TODO: Slow (needs to be done for each row)?
+		auto fieldWidth = static_cast<int>(std::to_string(tracks.size()).size());
+		return settings.general.track_numbers == lib::context_all
+			? QString("%1").arg(row + 1, fieldWidth)
+			: QString();
+	}
+
+	if (column == TrackListColumn::Name)
+	{
+		return QString::fromStdString(track.name);
+	}
+
+	if (column == TrackListColumn::Artists)
+	{
+		auto names = lib::spt::entity::combine_names(track.artists);
+		return QString::fromStdString(names);
+	}
+
+	if (column == TrackListColumn::Album)
+	{
+		return QString::fromStdString(track.album.name);
+	}
+
+	if (column == TrackListColumn::Duration)
+	{
+		auto time = lib::fmt::time(track.duration);
+		return QString::fromStdString(time);
+	}
+
+	if (column == TrackListColumn::AddedAt)
+	{
+		if (track.added_at.empty())
+		{
+			return QString();
+		}
+
+		if (settings.general.relative_added)
+		{
+			return DateUtils::toRelative(track.added_at);
+		}
+
+		auto date = DateUtils::fromIso(track.added_at).date();
+		return QLocale::system().toString(date, QLocale::ShortFormat);
+	}
+
+	return QString();
+}
+
+auto TrackListModel::trackIds() const -> std::vector<std::string>
+{
+	std::vector<std::string> items;
+	items.reserve(tracks.size());
+
+	for (const auto &track : tracks)
+	{
+		if (!track.is_valid())
+		{
+			continue;
+		}
+		items.push_back(lib::spt::api::to_uri("track", track.id));
+	}
+
+	return items;
 }

--- a/src/model/tracklistmodel.hpp
+++ b/src/model/tracklistmodel.hpp
@@ -8,6 +8,7 @@
 #include "role/tracklistcolumn.hpp"
 #include "util/dateutils.hpp"
 #include "lib/spotify/api.hpp"
+#include "list/tracklistitem.hpp"
 
 #include <QAbstractListModel>
 #include <QLocale>
@@ -46,8 +47,12 @@ protected:
 
 private:
 	const lib::settings &settings;
-	std::vector<lib::spt::track> tracks;
+	std::vector<TrackListItem> tracks;
 	QIcon emptyIcon;
 
+	/** Qt::DisplayRole */
 	auto displayRole(TrackListColumn column, int row) const -> QString;
+
+	/** Qt::ToolTipRole */
+	auto tooltip(TrackListColumn column, int row) const -> QString;
 };

--- a/src/model/tracklistmodel.hpp
+++ b/src/model/tracklistmodel.hpp
@@ -38,7 +38,7 @@ public:
 	auto headerData(int section, Qt::Orientation orientation,
 		int role) const -> QVariant override;
 
-	auto at(int index) -> const lib::spt::track &;
+	auto at(int index) -> const TrackListItem &;
 
 	auto trackIds() const -> std::vector<std::string>;
 

--- a/src/model/tracklistmodel.hpp
+++ b/src/model/tracklistmodel.hpp
@@ -11,6 +11,7 @@
 
 #include <QAbstractListModel>
 #include <QLocale>
+#include <QIcon>
 
 class TrackListModel: public QAbstractListModel
 {
@@ -46,6 +47,7 @@ protected:
 private:
 	const lib::settings &settings;
 	std::vector<lib::spt::track> tracks;
+	QIcon emptyIcon;
 
 	auto displayRole(TrackListColumn column, int row) const -> QString;
 };

--- a/src/model/tracklistmodel.hpp
+++ b/src/model/tracklistmodel.hpp
@@ -4,17 +4,24 @@
 #include "lib/spotify/track.hpp"
 #include "metatypes.hpp"
 #include "lib/vector.hpp"
+#include "lib/settings.hpp"
+#include "role/tracklistcolumn.hpp"
+#include "util/dateutils.hpp"
+#include "lib/spotify/api.hpp"
 
 #include <QAbstractListModel>
+#include <QLocale>
 
 class TrackListModel: public QAbstractListModel
 {
 Q_OBJECT
 
 public:
-	explicit TrackListModel(QObject *parent);
+	explicit TrackListModel(const lib::settings &settings, QObject *parent);
 
 	void add(const std::vector<lib::spt::track> &tracks);
+
+	void remove(lib::spt::track &track);
 
 	void clear();
 
@@ -26,11 +33,19 @@ public:
 	auto data(const QModelIndex &index, int role) const -> QVariant override;
 	auto data(const QModelIndex &index) const -> QVariant;
 
-	auto parent(const QModelIndex &child) const -> QModelIndex override;
+	auto headerData(int section, Qt::Orientation orientation,
+		int role) const -> QVariant override;
+
+	auto at(int index) -> const lib::spt::track &;
+
+	auto trackIds() const -> std::vector<std::string>;
 
 protected:
 	auto roleNames() const -> QHash<int, QByteArray> override;
 
 private:
+	const lib::settings &settings;
 	std::vector<lib::spt::track> tracks;
+
+	auto displayRole(TrackListColumn column, int row) const -> QString;
 };

--- a/src/role/tracklistcolumn.hpp
+++ b/src/role/tracklistcolumn.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+enum class TrackListColumn
+{
+	Number = 0,
+	Name = 1,
+	Artists = 2,
+	Album = 3,
+	Duration = 4,
+	AddedAt = 5,
+};

--- a/src/role/tracklistroles.hpp
+++ b/src/role/tracklistroles.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-enum class TrackListRole
+enum TrackListRole
 {
-	Track,
-	Index,
+	TrackRoleTrack = 0x100,
+	TrackRoleIndex = 0x101,
 };

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -1,6 +1,6 @@
 #include "trayicon.hpp"
 
-TrayIcon::TrayIcon(spt::Spotify *spotify, const lib::settings &settings, QObject *parent)
+TrayIcon::TrayIcon(spt::Spotify *spotify, const lib::settings &settings, QWidget *parent)
 	: spotify(spotify),
 	settings(settings),
 	QSystemTrayIcon(parent)
@@ -10,7 +10,7 @@ TrayIcon::TrayIcon(spt::Spotify *spotify, const lib::settings &settings, QObject
 		this->message(QString::fromStdString(result));
 	};
 
-	contextMenu = new QMenu();
+	contextMenu = new QMenu(parent);
 	currentTrack = contextMenu->addAction("-");
 	currentTrack->setEnabled(false);
 	contextMenu->addSeparator();
@@ -27,9 +27,13 @@ TrayIcon::TrayIcon(spt::Spotify *spotify, const lib::settings &settings, QObject
 	QAction::connect(playPause, &QAction::triggered, [this](bool /*checked*/)
 	{
 		if (playback().is_playing)
+		{
 			this->spotify->pause(this->callback);
+		}
 		else
+		{
 			this->spotify->resume(this->callback);
+		}
 	});
 
 	auto *next = contextMenu->addAction(Icon::get("media-skip-forward"), "Next");

--- a/src/trayicon.hpp
+++ b/src/trayicon.hpp
@@ -15,7 +15,7 @@ class TrayIcon: private QSystemTrayIcon
 Q_OBJECT
 
 public:
-	TrayIcon(spt::Spotify *spotify, const lib::settings &settings, QObject *parent);
+	TrayIcon(spt::Spotify *spotify, const lib::settings &settings, QWidget *parent);
 	~TrayIcon() override;
 
 	void message(const QString &message);


### PR DESCRIPTION
`TrackList` currently makes use of `QTreeWidget` which is designed for simple lists. The track list has become very complex over time and reworking it to use `QTreeView` with a proper model instead would increase performance and maintainability (hopefully).

**This feature is very incomplete and needs a lot of testing before being merged.**