### PR TITLE
Fix minimize button on systems with buggy Qt windowState

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -220,6 +220,16 @@ void MainWindow::addSizeGrip(const std::function<QPoint(const QRect &)> &positio
 	resizeGrips.append(sizeGrip);
 }
 
+void MainWindow::minimize()
+{
+	// HACK: Qt windows that are restored are sometimes still marked minimized
+	// so we have to remove that flag if present before trying to minimize.
+	//
+	// See https://github.com/kraxarn/spotify-qt/issues/103
+	setWindowState(windowState() & ~Qt::WindowMinimized);
+	setWindowState(windowState() | Qt::WindowMinimized);
+}
+
 void MainWindow::refresh()
 {
 	constexpr int msInSec = 1000;

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -54,6 +54,7 @@ public:
 	void orderPlaylists(lib::playlist_order order);
 	void setBorderless(bool enabled);
 	void addSizeGrip(const std::function<QPoint(const QRect&)> &position);
+	void minimize();
 
 	auto startClient() -> bool;
 	void stopClient();

--- a/src/widget/dragarea.cpp
+++ b/src/widget/dragarea.cpp
@@ -58,7 +58,7 @@ void DragArea::menu(const QPoint &pos)
 		"Minimize");
 	QAction::connect(minimize, &QAction::triggered, [this](bool /*checked*/)
 	{
-		mainWindow->setWindowState(Qt::WindowMinimized);
+		static_cast<MainWindow *>(mainWindow)->minimize();
 	});
 
 	const auto isMaximized = isWindowMaximized();

--- a/src/widget/maintoolbar.cpp
+++ b/src/widget/maintoolbar.cpp
@@ -283,5 +283,10 @@ void MainToolBar::onRepeat(bool checked)
 void MainToolBar::onMinimize(bool /*checked*/)
 {
 	auto *mainWindow = MainWindow::find(parentWidget());
-	mainWindow->setWindowState(Qt::WindowMinimized);
+	// HACK: Qt windows that are restored are sometimes still marked minimized
+	// so we have to remove that flag if present before trying to minimize.
+	//
+	// See https://github.com/kraxarn/spotify-qt/issues/103
+	mainWindow->setWindowState(mainWindow->windowState() & ~Qt::WindowMinimized);
+	mainWindow->setWindowState(mainWindow->windowState() | Qt::WindowMinimized);
 }

--- a/src/widget/maintoolbar.cpp
+++ b/src/widget/maintoolbar.cpp
@@ -283,10 +283,5 @@ void MainToolBar::onRepeat(bool checked)
 void MainToolBar::onMinimize(bool /*checked*/)
 {
 	auto *mainWindow = MainWindow::find(parentWidget());
-	// HACK: Qt windows that are restored are sometimes still marked minimized
-	// so we have to remove that flag if present before trying to minimize.
-	//
-	// See https://github.com/kraxarn/spotify-qt/issues/103
-	mainWindow->setWindowState(mainWindow->windowState() & ~Qt::WindowMinimized);
-	mainWindow->setWindowState(mainWindow->windowState() | Qt::WindowMinimized);
+    mainWindow->minimize();
 }


### PR DESCRIPTION
This also maintains maximize state across minimizes.

Fixes #103
