### PR TITLE
Playlist refresh

### DIFF
--- a/src/menu/songmenu.cpp
+++ b/src/menu/songmenu.cpp
@@ -266,6 +266,9 @@ void SongMenu::remFromPlaylist(bool /*checked*/)
 			// It doesn't necessarily match item index depending on sorting order
 			mainWindow->getSongsTree()->takeTopLevelItem(i);
 
+            // Refresh the playlist automatically to prevent issues with songs being skipped
+            mainWindow->getSongsTree()->refreshPlaylist(currentPlaylist);
+
 			StatusMessage::info(QString("Removed %1 from \"%2\"")
 				.arg(QString::fromStdString(track.title()))
 				.arg(QString::fromStdString(currentPlaylist.name)));

--- a/src/menu/songmenu.cpp
+++ b/src/menu/songmenu.cpp
@@ -266,8 +266,8 @@ void SongMenu::remFromPlaylist(bool /*checked*/)
 			// It doesn't necessarily match item index depending on sorting order
 			mainWindow->getSongsTree()->takeTopLevelItem(i);
 
-            // Refresh the playlist automatically to prevent issues with songs being skipped
-            mainWindow->getSongsTree()->refreshPlaylist(currentPlaylist);
+			// Refresh the playlist automatically to prevent issues with songs being skipped
+			mainWindow->getSongsTree()->refreshPlaylist(currentPlaylist);
 
 			StatusMessage::info(QString("Removed %1 from \"%2\"")
 				.arg(QString::fromStdString(track.title()))


### PR DESCRIPTION
This pull request is provided to fix #128.

All it does is add a call to `refreshPlaylist(currentPlaylist)` when removing a song from a playlist to prevent the app from skipping the track taking the place of the deleted track.

If you believe that this needs modifications, let me know and I will be happy to improve this pull request.