### PR TITLE
Fix a build issue with LLVM 10 + qt 5.15.2 on BSD

### DIFF
--- a/src/dialog/setupdialog.hpp
+++ b/src/dialog/setupdialog.hpp
@@ -12,6 +12,7 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QPushButton>
+#include <QTcpSocket>
 #include <QTcpServer>
 #include <QUrl>
 #include <QVBoxLayout>


### PR DESCRIPTION
Noticed a build problem as the tcp socket doesn't get pulled in for the tcp server header in the right order.