### PR TITLE
Hide to system tray instead of quitting

### DIFF
--- a/lib/include/lib/settings/general.hpp
+++ b/lib/include/lib/settings/general.hpp
@@ -129,6 +129,11 @@ namespace lib
 			 * Show a notification on track change
 			 */
 			bool notify_track_change = false;
+
+			/**
+			 * Close to system tray instead of quitting when the close button is pressed
+			 */
+			bool close_to_tray = false;
 		};
 
 		void to_json(nlohmann::json &j, const general &g);

--- a/lib/src/settings/general.cpp
+++ b/lib/src/settings/general.cpp
@@ -3,6 +3,7 @@
 void lib::setting::to_json(nlohmann::json &j, const general &g)
 {
 	j = nlohmann::json{
+		{"close_to_tray", g.close_to_tray},
 		{"custom_playlist_order", g.custom_playlist_order},
 		{"fallback_icons", g.fallback_icons},
 		{"fixed_width_time", g.fixed_width_time},
@@ -35,6 +36,7 @@ void lib::setting::from_json(const nlohmann::json &j, general &g)
 		return;
 	}
 
+	lib::json::get(j, "close_to_tray", g.close_to_tray);
 	lib::json::get(j, "custom_playlist_order", g.custom_playlist_order);
 	lib::json::get(j, "fallback_icons", g.fallback_icons);
 	lib::json::get(j, "fixed_width_time", g.fixed_width_time);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -92,8 +92,16 @@ MainWindow::MainWindow(lib::settings &settings, lib::paths &paths)
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
-	delete trayIcon;
-	event->accept();
+	if (settings.general.close_to_tray && trayIcon != nullptr)
+	{
+		event->ignore();
+		this->setVisible(false);
+	}
+	else
+	{
+		delete trayIcon;
+		event->accept();
+	}
 }
 
 void MainWindow::initClient()

--- a/src/settingspage/interface.cpp
+++ b/src/settingspage/interface.cpp
@@ -152,6 +152,11 @@ auto SettingsPage::Interface::trayIcon() -> QWidget *
 	notifyTrackChange->setChecked(settings.general.notify_track_change);
 	trayOptions->addWidget(notifyTrackChange);
 
+	closeToTray = new QCheckBox("Close to system tray instead of quitting", this);
+	closeToTray->setToolTip("The app will remain active with the icon in system tray after the close button is pressed");
+	closeToTray->setChecked(settings.general.close_to_tray);
+	trayOptions->addWidget(closeToTray);
+
 	return Widget::layoutToWidget(content, this);
 }
 
@@ -308,6 +313,11 @@ void SettingsPage::Interface::saveTrayIcon()
 	if (notifyTrackChange != nullptr)
 	{
 		settings.general.notify_track_change = notifyTrackChange->isChecked();
+	}
+
+	if (closeToTray != nullptr)
+	{
+		settings.general.close_to_tray = closeToTray->isChecked();
 	}
 
 	// Reload if needed

--- a/src/settingspage/interface.hpp
+++ b/src/settingspage/interface.hpp
@@ -37,6 +37,7 @@ namespace SettingsPage
 		QCheckBox *albumInTray = nullptr;
 		QCheckBox *invertTrayIcon = nullptr;
 		QCheckBox *notifyTrackChange = nullptr;
+		QCheckBox *closeToTray = nullptr;
 
 		// Title bar
 		QGroupBox *appTitleBar = nullptr;

--- a/src/view/maintoolbar.cpp
+++ b/src/view/maintoolbar.cpp
@@ -91,7 +91,7 @@ MainToolBar::MainToolBar(lib::spt::api &spotify, lib::settings &settings,
 	close = new QAction(Icon::get("window-close"),
 		QStringLiteral("Close"), this);
 
-	QAction::connect(close, &QAction::triggered, &QCoreApplication::quit);
+	QAction::connect(close, &QAction::triggered, this, &MainToolBar::onClose);
 
 	if (settings.qt().mirror_title_bar)
 	{
@@ -359,4 +359,17 @@ void MainToolBar::onMinimize(bool /*checked*/)
 {
 	auto *mainWindow = MainWindow::find(parentWidget());
 	mainWindow->minimize();
+}
+
+void MainToolBar::onClose(bool /*checked*/)
+{
+	auto *mainWindow = MainWindow::find(parentWidget());
+	if (settings.general.close_to_tray && mainWindow->getTrayIcon() != nullptr)
+	{
+		mainWindow->setVisible(false);
+	}
+	else
+	{
+		QCoreApplication::quit();
+	}
 }

--- a/src/view/maintoolbar.hpp
+++ b/src/view/maintoolbar.hpp
@@ -48,6 +48,7 @@ private:
 	void onShuffle(bool checked);
 	void onRepeat(bool checked);
 	void onMinimize(bool checked);
+	void onClose(bool checked);
 
 	lib::repeat_state repeatState = lib::repeat_state::off;
 


### PR DESCRIPTION
Related issues:
https://github.com/kraxarn/spotify-qt/issues/124
https://github.com/kraxarn/spotify-qt/issues/71

This adds an option to hide the app to system tray with the close button.
The default behaviour remains unchanged.

I've tested it on Linux.