### PR TITLE
Add ctrl+f key binding to search

### DIFF
--- a/src/view/maintoolbar.cpp
+++ b/src/view/maintoolbar.cpp
@@ -25,6 +25,7 @@ MainToolBar::MainToolBar(lib::spt::api &spotify, lib::settings &settings,
 	// Search
 	search = addAction(Icon::get("edit-find"), "Search");
 	search->setCheckable(true);
+	search->setShortcut(QKeySequence::Find);
 	QAction::connect(search, &QAction::triggered, mainWindow, &MainWindow::setSearchVisible);
 
 	// Media controls


### PR DESCRIPTION
Related issue: https://github.com/kraxarn/spotify-qt/issues/118

With this change you can open and close the search pane with `ctrl+f`.
From what I see, the input field is automatically selected every time, so there's no additional need to click anything, just do `ctrl+f` `<search>` `enter`.