### PR TITLE
Added xdg and Windows paths to spotifyd .conf detection

### DIFF
--- a/src/settingspage/spotify.cpp
+++ b/src/settingspage/spotify.cpp
@@ -311,10 +311,12 @@ void SettingsPage::Spotify::startClientToggle(int state)
 
 auto SettingsPage::Spotify::sptConfigExists() -> bool
 {
-	// Config is either ~/.config/spotifyd/spotifyd.conf or /etc/spotifyd/spotifyd.conf
+	// Config is either ~/.config/spotifyd/spotifyd.conf or /etc/spotifyd/spotifyd.conf or /etc/xdg/spotifyd/spotifyd.conf or ~\AppData\Roaming\spotifyd\spotifyd.conf
 	return QFile(QString("%1/.config/spotifyd/spotifyd.conf")
 		.arg(QStandardPaths::standardLocations(QStandardPaths::HomeLocation)[0])).exists()
-		|| QFile("/etc/spotifyd/spotifyd.conf").exists();
+		|| QFile("/etc/spotifyd/spotifyd.conf").exists()
+		|| QFile("/etc/xdg/spotifyd/spotifyd.conf").exists()
+		|| QFile("%1\\AppData\\Roaming\\spotifyd\\spotifyd.conf").exists();
 }
 
 auto SettingsPage::Spotify::backends() -> QStringList


### PR DESCRIPTION
https://github.com/Spotifyd/spotifyd/blob/master/docs/src/config/File.md#configuration-file <- xdg paths
https://github.com/Spotifyd/spotifyd/pull/602#issue-637236835 <- Windows paths
I built this PR, and the spotifyd PR on Windows, and can confirm that it works :)