### PR TITLE
Also run spotifyd with --no-daemon flag when using global config

### DIFF
--- a/src/spotifyclient/runner.cpp
+++ b/src/spotifyclient/runner.cpp
@@ -47,7 +47,7 @@ auto SpotifyClient::Runner::start() -> QString
 	// If using global config, just start
 	if (settings.spotify.global_config && clientType == lib::client_type::spotifyd)
 	{
-		process->start(path, QStringList());
+		process->start(path, QStringList({"--no-daemon"}));
 		return {};
 	}
 


### PR DESCRIPTION
This is so that spotify-qt can still stop the spotifyd service when using a global config. This is needed because spotifyd doesn't provide a config file option to run without detaching.