### PR TITLE
Fix broken track sharing links

### DIFF
--- a/src/menu/track.cpp
+++ b/src/menu/track.cpp
@@ -451,8 +451,8 @@ auto Menu::Track::getTrackUrl() const -> QString
 		return {};
 	}
 
-	const auto trackUri = lib::spt::api::to_uri("tracks", tracks.cbegin()->second.id);
-	auto str = lib::fmt::format("https://open.spotify.com/track/{}", trackUri);
+	const auto trackId = lib::spt::api::to_id(tracks.cbegin()->second.id);
+	auto str = lib::fmt::format("https://open.spotify.com/track/{}", trackId);
 	return QString::fromStdString(str);
 }
 

--- a/src/menu/track.cpp
+++ b/src/menu/track.cpp
@@ -451,7 +451,7 @@ auto Menu::Track::getTrackUrl() const -> QString
 		return {};
 	}
 
-	const auto trackId = lib::spt::api::to_id(tracks.cbegin()->second.id);
+	const auto trackId = tracks.cbegin()->second.id;
 	auto str = lib::fmt::format("https://open.spotify.com/track/{}", trackId);
 	return QString::fromStdString(str);
 }


### PR DESCRIPTION
Currently when sharing or opening a song, the url uses the uri object, which does not work.
This PR aims to fix this by swapping from uri to id.
![image_236](https://user-images.githubusercontent.com/18603393/167568110-7bfd363c-b851-403c-a1d5-33b62dfea75b.png)

Example:
https://open.spotify.com/track/spotify:tracks:1GUATj8VacuwLanT47pRmH
PR:
https://open.spotify.com/track/1GUATj8VacuwLanT47pRmH