### PR TITLE
Fix MPRIS supportedUriSchemes typo

### DIFF
--- a/src/mediaplayer/mediaplayer.cpp
+++ b/src/mediaplayer/mediaplayer.cpp
@@ -33,7 +33,7 @@ auto MediaPlayer::identity() const -> QString
 	return QCoreApplication::applicationName();
 }
 
-auto MediaPlayer::supportedUriSchemas() const -> QStringList
+auto MediaPlayer::supportedUriSchemes() const -> QStringList
 {
 	return QStringList("spotify");
 }

--- a/src/mediaplayer/mediaplayer.hpp
+++ b/src/mediaplayer/mediaplayer.hpp
@@ -24,7 +24,7 @@ Q_OBJECT
 	Q_PROPERTY(bool CanRaise READ canQuit)
 	Q_PROPERTY(QString Identity READ identity)
 	Q_PROPERTY(QString DesktopEntry READ identity)
-	Q_PROPERTY(QStringList SupportedUriSchemas READ supportedUriSchemas)
+	Q_PROPERTY(QStringList SupportedUriSchemes READ supportedUriSchemes)
 	Q_PROPERTY(QStringList SupportedMimeTypes READ supportedMimeTypes)
 	Q_PROPERTY(bool HasTrackList READ hasTrackList)
 
@@ -34,7 +34,7 @@ public:
 	auto canQuit() const -> bool;
 	auto hasTrackList() const -> bool;
 	auto identity() const -> QString;
-	auto supportedUriSchemas() const -> QStringList;
+	auto supportedUriSchemes() const -> QStringList;
 	auto supportedMimeTypes() const -> QStringList;
 
 public slots:


### PR DESCRIPTION
KDE Media Player's applet now picks up spotify-qt with this fix.

Current track info shows, next/previous/pause buttons work. Seems like there is an issue with trying to resume playback though but that is unrelated to this commit.