### PR TITLE
mainwindow: check if a trayicon was already created

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -56,7 +56,7 @@ void MainWindow::showEvent(QShowEvent *event)
 	initMediaController();
 
 	// Create tray icon if specified
-	if (settings.general.tray_icon)
+	if (settings.general.tray_icon && !trayIcon)
 	{
 		trayIcon = new TrayIcon(spotify, settings, cache, this);
 	}


### PR DESCRIPTION
Currently, a new TrayIcon is created each time I press the icon to open the app.
There's no need to create a new TrayIcon if it was previously created - this PR adds a check for this.

![Screenshot_20220822_180311](https://user-images.githubusercontent.com/48583927/185966693-8ad57764-2826-4278-8f55-20abdb059d24.png)


Please note, that this is all about the function `showEvent`, which is called every time we click on the TrayIcon, and it calls some functions that could be affected similarily. For example, should `initDevice` be called each time? (this is out of scope for the PR but could be useful in general, so I'm just leaving it here)
