### PR TITLE
Show tooltips previewing URLs in ArtistLinks menu

### DIFF
--- a/src/menu/artistlinks.cpp
+++ b/src/menu/artistlinks.cpp
@@ -8,6 +8,7 @@ Menu::ArtistLinks::ArtistLinks(const lib::spt::artist &artist,
 {
 	setIcon(Icon::get("edit-find"));
 	setTitle("Links");
+	setToolTipsVisible(true);
 
 	QMenu::connect(this, &QMenu::aboutToShow,
 		this, &Menu::ArtistLinks::onAboutToShow);
@@ -43,6 +44,7 @@ void Menu::ArtistLinks::onDuckDuckGo(bool /*checked*/)
 void Menu::ArtistLinks::addLink(const std::string &title, const std::string &url)
 {
 	auto *action = addAction(QString::fromStdString(title));
+	action->setToolTip(QString::fromStdString(url));
 	QAction::connect(action, &QAction::triggered, [this, url](bool /*checked*/)
 	{
 		Url::open(url, LinkType::Web, this);


### PR DESCRIPTION
Just one of those little features that I was missing when I was digging around in Spotify :-)

Also, this enables tooltips on the artist menu such that you can preview the URL you're about to open in your web browser.

EDIT: somehow I was confusing something here. Lemme go dig into this a bit tomorrow.