### PR TITLE
feat: Adds support for passing custom arguments to the spotify client

### DIFF
--- a/lib/include/lib/settings/spotify.hpp
+++ b/lib/include/lib/settings/spotify.hpp
@@ -31,6 +31,11 @@ namespace lib
 			std::string username;
 
 			/**
+			 * Additional arugments to pass to the spotify client
+			 */
+			std::string additional_arguments;
+
+			/**
 			 * Always start Spotify client on application start
 			 */
 			bool always_start = true;

--- a/lib/src/settings/spotify.cpp
+++ b/lib/src/settings/spotify.cpp
@@ -14,6 +14,7 @@ void lib::setting::to_json(nlohmann::json &j, const spotify &s)
 		{"start_client", s.start_client},
 		{"username", s.username},
 		{"volume", s.volume},
+		{"additional_arguments", s.additional_arguments},
 	};
 }
 
@@ -35,4 +36,5 @@ void lib::setting::from_json(const nlohmann::json &j, spotify &s)
 	lib::json::get(j, "start_client", s.start_client);
 	lib::json::get(j, "username", s.username);
 	lib::json::get(j, "volume", s.volume);
+	lib::json::get(j, "additional_arguments", s.additional_arguments);
 }

--- a/src/settingspage/spotify.cpp
+++ b/src/settingspage/spotify.cpp
@@ -228,13 +228,20 @@ auto SettingsPage::Spotify::config() -> QWidget *
 	sptDeviceType->addItem(QStringLiteral("Default"));
 	sptLayout->addWidget(sptDeviceType, 3, 1);
 
+	// Additional arguments
+	auto *additionalArgumentsLabel = new QLabel(QStringLiteral("Additional arguments"), sptGroup);
+	sptLayout->addWidget(additionalArgumentsLabel, 4, 0);
+
+	sptAdditionalArguments = new QLineEdit(QString::fromStdString(settings.spotify.additional_arguments), sptGroup);
+	sptLayout->addWidget(sptAdditionalArguments, 4, 1);
+
 	// Clear password
 #ifdef USE_KEYCHAIN
 	auto *clearPasswordText = new QLabel(QStringLiteral("Clear saved password"));
-	sptLayout->addWidget(clearPasswordText, 4, 0);
+	sptLayout->addWidget(clearPasswordText, 5, 0);
 
 	auto *clearPassword = new QPushButton(QStringLiteral("Clear"), this);
-	sptLayout->addWidget(clearPassword, 4, 1, Qt::AlignTrailing);
+	sptLayout->addWidget(clearPassword, 5, 1, Qt::AlignTrailing);
 
 	QAbstractButton::connect(clearPassword, &QAbstractButton::clicked,
 		this, &SettingsPage::Spotify::onClearPassword);
@@ -244,7 +251,7 @@ auto SettingsPage::Spotify::config() -> QWidget *
 	sptDiscovery = new QCheckBox("Enable discovery");
 	sptDiscovery->setToolTip("Enable discovery mode (librespot only)");
 	sptDiscovery->setChecked(!settings.spotify.disable_discovery);
-	sptLayout->addWidget(sptDiscovery, 5, 0);
+	sptLayout->addWidget(sptDiscovery, 6, 0);
 
 	return Widget::layoutToWidget(content, this);
 }
@@ -358,6 +365,11 @@ auto SettingsPage::Spotify::save() -> bool
 			? lib::audio_quality::normal : bitrate == 1
 				? lib::audio_quality::high
 				: lib::audio_quality::very_high;
+	}
+
+	if (sptAdditionalArguments != nullptr)
+	{
+		settings.spotify.additional_arguments = sptAdditionalArguments->text().toStdString();
 	}
 
 	if (sptAlways != nullptr)

--- a/src/settingspage/spotify.hpp
+++ b/src/settingspage/spotify.hpp
@@ -37,6 +37,7 @@ namespace SettingsPage
 		QLineEdit *sptPath = nullptr;
 		QLineEdit *sptUsername = nullptr;
 		QCheckBox *sptDiscovery = nullptr;
+		QLineEdit *sptAdditionalArguments = nullptr;
 
 		QPushButton *startClient = nullptr;
 		QLabel *clientStatus = nullptr;

--- a/src/spotifyclient/runner.cpp
+++ b/src/spotifyclient/runner.cpp
@@ -156,6 +156,12 @@ void SpotifyClient::Runner::start(const QString &username, const QString &passwo
 		}
 	}
 
+	auto additional_arguments = QString::fromStdString(settings.spotify.additional_arguments);
+	if (!additional_arguments.isEmpty())
+	{
+		arguments.append(additional_arguments.split(' '));
+	}
+
 	QProcess::connect(process, &QProcess::readyReadStandardOutput,
 		this, &Runner::onReadyReadOutput);
 


### PR DESCRIPTION
Enables users with specific requirements to pass additional arguments when launching a spotify client with spotify-qt.