### PR TITLE
Add "Add to liked albums" button to albums menu

### DIFF
--- a/lib/include/lib/spotify/api.hpp
+++ b/lib/include/lib/spotify/api.hpp
@@ -102,6 +102,15 @@ namespace lib
 
 			void saved_albums(const paged_callback<saved_album> &callback) const;
 
+			void add_saved_albums(const std::vector<std::string> &album_ids,
+				lib::callback<std::string> &callback);
+
+			void remove_saved_albums(const std::vector<std::string> &album_ids,
+				lib::callback<std::string> &callback);
+
+			void is_saved_album(const std::vector<std::string> &album_ids,
+				lib::callback<std::vector<bool>> &callback);
+
 			/**
 			 * @deprecated Use with pagination instead
 			 */

--- a/lib/src/spotifyapi/library.cpp
+++ b/lib/src/spotifyapi/library.cpp
@@ -1,13 +1,35 @@
 #include "lib/spotify/api.hpp"
 
 // Currently unavailable:
-// me/albums/contains
 // me/shows
 // me/shows/contains
 
 void lib::spt::api::saved_albums(const paged_callback<saved_album> &callback) const
 {
 	request.get_page<saved_album>("me/albums", {}, callback);
+}
+
+void lib::spt::api::add_saved_albums(const std::vector<std::string> &album_ids,
+	lib::callback<std::string> &callback)
+{
+	put("me/albums", {
+		{"ids", album_ids},
+	}, callback);
+}
+
+void lib::spt::api::remove_saved_albums(const std::vector<std::string> &album_ids,
+	lib::callback<std::string> &callback)
+{
+	del("me/albums", {
+		{"ids", album_ids},
+	}, callback);
+}
+
+void lib::spt::api::is_saved_album(const std::vector<std::string> &album_ids,
+	lib::callback<std::vector<bool>> &callback)
+{
+	get(lib::fmt::format("me/albums/contains?ids={}",
+		lib::strings::join(album_ids, ",")), callback);
 }
 
 void lib::spt::api::saved_tracks(lib::callback<std::vector<lib::spt::track>> &callback)

--- a/src/menu/album.hpp
+++ b/src/menu/album.hpp
@@ -19,18 +19,23 @@ namespace Menu
 			const std::string &albumId, QWidget *parent);
 
 	private:
+		bool isLiked = false;
+
 		std::vector<lib::spt::track> tracks;
 		lib::spt::album album;
 		lib::spt::api &spotify;
 		lib::cache &cache;
 
+		QAction *toggleLikedAlbum = nullptr;
 		QAction *trackCount = nullptr;
 		AddToPlaylist *addToPlaylist = nullptr;
 
+		void setLikedAlbum(bool liked);
 		void tracksLoaded();
 		auto getTrackIds() const -> std::vector<std::string>;
 
 		void onShuffle(bool checked);
+		void onLikeAlbum(bool checked);
 		void onCopyLink(bool checked);
 		void onCopyName(bool checked);
 		void onOpenInSpotify(bool checked);


### PR DESCRIPTION
Hello! The one feature holding me back from using spotify-qt full time was the lack of a "Add to liked albums" button, so I added it in this PR.