### PR TITLE
fix #219: Off-by-one error for added time hidden state

### DIFF
--- a/src/list/tracks.cpp
+++ b/src/list/tracks.cpp
@@ -528,7 +528,7 @@ auto List::Tracks::load(const lib::spt::page<lib::spt::track> &page,
 
 	constexpr int addedColumn = static_cast<int>(Column::Added);
 	const auto &hiddenHeaders = settings.general.hidden_song_headers;
-	const auto isAddedHidden = lib::set::contains(hiddenHeaders, addedColumn);
+	const auto isAddedHidden = lib::set::contains(hiddenHeaders, addedColumn - 1);
 
 	// Hide until track with date is inserted
 	header()->setSectionHidden(addedColumn, true);


### PR DESCRIPTION
This fixes the added column not persisting on application restart or loading another Tracks list by accounting for the values in `settings.general.hidden_song_headers` being 1 lower than the values defined in the `Column` enum.