### PR TITLE
Change localhost to 127.0.0.1 to comply with Spotify auth changes

### DIFF
--- a/src/dialog/setup.cpp
+++ b/src/dialog/setup.cpp
@@ -16,7 +16,7 @@ Dialog::Setup::Setup(lib::settings &settings, QWidget *parent)
 		"Welcome to %1!\n"
 		"Before using the app, you need to setup your Spotify Web API keys.\n"
 		"You can do this by opening the Spotify Dashboard, create a new app and \n"
-		"set the redirect uri (not website) to http://localhost:8888.\n"
+		"set the redirect uri (not website) to http://127.0.0.1:8888.\n"
 		"Then, enter your Client ID and secret below from the same application page:")
 		.arg(APP_NAME), this);
 	layout->addWidget(welcomeText);

--- a/src/spotify/authserver.cpp
+++ b/src/spotify/authserver.cpp
@@ -12,12 +12,12 @@ spt::AuthServer::AuthServer(lib::settings &settings, QObject *parent)
 
 auto spt::AuthServer::listen() -> bool
 {
-	return QTcpServer::listen(QHostAddress::LocalHost, serverPort);
+	return QTcpServer::listen(QHostAddress("127.0.0.1"), serverPort);
 }
 
 auto spt::AuthServer::redirectUrl() -> QString
 {
-	return QString("http://localhost:%1").arg(serverPort);
+	return QString("http://127.0.0.1:%1").arg(serverPort);
 }
 
 void spt::AuthServer::openUrl(QWidget *parent) const


### PR DESCRIPTION
Spotify will soon update their authentication flow to block all HTTP redirect URIs, including `http://localhost`. They will still allow loopback IP addresses such as `http://127.0.0.1` and `http://[::1]`. This commit just changes all mentions of `localhost` to `127.0.0.1`. I don't think the implicit grant change affects spotify-qt.

Source and discussion:
https://developer.spotify.com/blog/2025-02-12-increasing-the-security-requirements-for-integrating-with-spotify

https://community.spotify.com/t5/Spotify-for-Developers/Increasing-security-requirements-for-integration-with-Spotify/td-p/6709091