### PR TITLE
Fix build failure against Qt 6.9

### DIFF
--- a/src/dialog/apirequest.hpp
+++ b/src/dialog/apirequest.hpp
@@ -12,6 +12,7 @@
 #include <QTabWidget>
 #include <QPushButton>
 #include <QMessageBox>
+#include <QJsonDocument>
 #include <QJsonParseError>
 #include <QNetworkReply>
 #include <QCoreApplication>


### PR DESCRIPTION
Currently, build failure occurs when using Qt 6.9:

```
/build/spotify-qt-git/src/spotify-qt/src/dialog/apirequest.cpp: In member function ‘void Dialog::ApiRequest::sendRequest(bool)’:
/build/spotify-qt-git/src/spotify-qt/src/dialog/apirequest.cpp:72:48: error: incomplete type ‘QJsonDocument’ used in nested name specifier
   72 |                 auto jsonBody = QJsonDocument::fromJson(jsonRequest->toPlainText().toUtf8(),
      |                                                ^~~~~~~~
/build/spotify-qt-git/src/spotify-qt/src/dialog/apirequest.cpp:109:36: error: incomplete type ‘QJsonDocument’ used in nested name specifier
  109 |         auto json = QJsonDocument::fromJson(replyBody, &jsonParseError);
      |                                    ^~~~~~~~
/build/spotify-qt-git/src/spotify-qt/src/dialog/apirequest.cpp:112:46: error: ‘QJsonDocument::JsonFormat’ has not been declared
  112 |                 ? json.toJson(QJsonDocument::JsonFormat::Indented)
      |                                              ^~~~~~~~~~
```

This pull request resolves the errors above.