### PR TITLE
Initial work on a queue sidebar panel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(spotify-qt LANGUAGES CXX VERSION 4.0.0)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-
+list(APPEND CMAKE_PREFIX_PATH "~/Qt/6.3.0/gcc_64")
 # C++17 is required on some platforms by Qt 6
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/lib/include/lib/settings/general.hpp
+++ b/lib/include/lib/settings/general.hpp
@@ -146,6 +146,11 @@ namespace lib
 			 * \brief Ignore index of unavailable tracks
 			 */
 			bool ignore_unavailable_index = false;
+
+			/**
+			 * Swap song name and artist name order in queue (Artist - Song instead of Song - Artist)
+			 */
+			bool queue_swap_name_format = false;
 		};
 
 		void to_json(nlohmann::json &j, const general &g);

--- a/lib/src/settings/general.cpp
+++ b/lib/src/settings/general.cpp
@@ -16,6 +16,7 @@ void lib::setting::to_json(nlohmann::json &j, const general &g)
 		{"native_window", g.native_window},
 		{"notify_track_change", g.notify_track_change},
 		{"playlist_order", g.playlist_order},
+		{"queue_swap_name_format", g.queue_swap_name_format},
 		{"refresh_interval", g.refresh_interval},
 		{"relative_added", g.relative_added},
 		{"show_changelog", g.show_changelog},
@@ -54,6 +55,7 @@ void lib::setting::from_json(const nlohmann::json &j, general &g)
 	lib::json::get(j, "native_window", g.native_window);
 	lib::json::get(j, "notify_track_change", g.notify_track_change);
 	lib::json::get(j, "playlist_order", g.playlist_order);
+	lib::json::get(j, "queue_swap_name_format", g.queue_swap_name_format);
 	lib::json::get(j, "refresh_interval", g.refresh_interval);
 	lib::json::get(j, "relative_added", g.relative_added);
 	lib::json::get(j, "show_changelog", g.show_changelog);

--- a/src/enum/sidepaneltype.hpp
+++ b/src/enum/sidepaneltype.hpp
@@ -19,4 +19,9 @@ enum class SidePanelType: char
 	 * Lyrics, paired with track ID
 	 */
 	Lyrics,
+
+	/**
+	 * Queue, not paired
+	 */
+	Queue,
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -89,6 +89,8 @@ MainWindow::MainWindow(lib::settings &settings, lib::paths &paths,
 		new MainMenuBar(spotify, settings, httpClient, cache, this);
 	}
 
+	// Queue dock widget is initially hidden and can be toggled via the toolbar button
+
 	QCoreApplication::instance()->installEventFilter(this);
 }
 
@@ -509,6 +511,8 @@ auto MainWindow::createCentralWidget() -> QWidget *
 	libraryList = new List::Library(spotify, cache, httpClient, settings, this);
 	playlistList = new List::Playlist(spotify, settings, cache, httpClient, this);
 	contextView = new Context::View(spotify, settings, cache, httpClient, this);
+	queueView = new Queue::View(spotify, settings, this);
+	queueView->setVisible(false); // Initially hidden
 
 	auto *libraryDock = Widget::createDockWidget(libraryList,
 		QStringLiteral("Library"), DockTitle::margins(), this);
@@ -526,6 +530,7 @@ auto MainWindow::createCentralWidget() -> QWidget *
 
 	addDockWidget(Qt::LeftDockWidgetArea, contextView);
 	addDockWidget(Qt::RightDockWidgetArea, sidePanel);
+	addDockWidget(Qt::RightDockWidgetArea, queueView);
 
 	return mainContent;
 }
@@ -767,6 +772,15 @@ void MainWindow::setSearchVisible(bool visible)
 	else
 	{
 		panel->closeSearch();
+	}
+}
+
+void MainWindow::toggleQueue()
+{
+	if (queueView != nullptr)
+	{
+		// Toggle visibility of the queue dock widget
+		queueView->setVisible(!queueView->isVisible());
 	}
 }
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -13,6 +13,7 @@
 #include "view/maintoolbar.hpp"
 #include "view/trayicon.hpp"
 #include "view/context/view.hpp"
+#include "view/queue/view.hpp"
 #include "widget/historybutton.hpp"
 
 #include <QListWidgetItem>
@@ -53,6 +54,7 @@ public:
 	void toggleTrackNumbers(bool enabled);
 	void toggleExpandableAlbum(lib::album_size albumSize);
 	void setSearchVisible(bool visible);
+	void toggleQueue();
 	void refreshPlaylists();
 	void setCurrentLibraryItem(QTreeWidgetItem *item);
 	lib::spt::playlist getPlaylist(int index);
@@ -122,6 +124,7 @@ private:
 	List::Library *libraryList = nullptr;
 	List::Playlist *playlistList = nullptr;
 	Context::View *contextView = nullptr;
+	Queue::View *queueView = nullptr;
 
 #ifdef USE_DBUS
 	mp::Service *mediaPlayer = nullptr;

--- a/src/settingspage/interface.cpp
+++ b/src/settingspage/interface.cpp
@@ -1,5 +1,6 @@
 #include "settingspage/interface.hpp"
 #include "mainwindow.hpp"
+#include "view/sidepanel/view.hpp"
 #include "lib/system.hpp"
 #include "util/appconfig.hpp"
 #include "util/widget.hpp"
@@ -97,6 +98,12 @@ auto SettingsPage::Interface::general() -> QWidget *
 	tabbedLibrary->setToolTip(QStringLiteral("Show library and playlists as tabs"));
 	tabbedLibrary->setChecked(qtSettings.library_layout == lib::library_layout::tabbed);
 	layout->addWidget(tabbedLibrary);
+
+	// Queue name format
+	queueSwapNameFormat = new QCheckBox(QStringLiteral("Swap Song Name - Artist Name in Queue"), this);
+	queueSwapNameFormat->setToolTip(QStringLiteral("Show queue items as \"Artist Name - Song Name\" instead of \"Song Name - Artist Name\""));
+	queueSwapNameFormat->setChecked(settings.general.queue_swap_name_format);
+	layout->addWidget(queueSwapNameFormat);
 
 	// Native window handle
 	// (Required to move window under Wayland)
@@ -363,6 +370,24 @@ void SettingsPage::Interface::saveGeneral()
 	if (nativeWindow != nullptr)
 	{
 		settings.general.native_window = nativeWindow->isChecked();
+	}
+
+	if (queueSwapNameFormat != nullptr)
+	{
+		const bool oldValue = settings.general.queue_swap_name_format;
+		const bool newValue = queueSwapNameFormat->isChecked();
+		
+		settings.general.queue_swap_name_format = newValue;
+		
+		// Refresh queue format if setting changed
+		if (oldValue != newValue && mainWindow != nullptr)
+		{
+			auto *sidePanel = mainWindow->findChild<SidePanel::View *>();
+			if (sidePanel != nullptr)
+			{
+				sidePanel->refreshQueueFormat();
+			}
+		}
 	}
 }
 

--- a/src/settingspage/interface.hpp
+++ b/src/settingspage/interface.hpp
@@ -29,6 +29,7 @@ namespace SettingsPage
 		QCheckBox *relativeAdded = nullptr;
 		QCheckBox *nativeWindow = nullptr;
 		QCheckBox *tabbedLibrary = nullptr;
+		QCheckBox *queueSwapNameFormat = nullptr;
 
 		// Appearance
 		QComboBox *qtStyle = nullptr;

--- a/src/view/CMakeLists.txt
+++ b/src/view/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(artist)
 add_subdirectory(context)
 add_subdirectory(log)
+add_subdirectory(queue)
 add_subdirectory(search)
 add_subdirectory(sidepanel)
 

--- a/src/view/maintoolbar.cpp
+++ b/src/view/maintoolbar.cpp
@@ -42,6 +42,12 @@ MainToolBar::MainToolBar(lib::spt::api &spotify, lib::settings &settings,
 	search->setShortcut(QKeySequence::Find);
 	QAction::connect(search, &QAction::triggered, mainWindow, &MainWindow::setSearchVisible);
 
+	// Queue
+	queue = new QAction(Icon::get(QStringLiteral("media-track-show-active")),
+		QStringLiteral("Toggle Queue"));
+	queue->setCheckable(true);
+	QAction::connect(queue, &QAction::triggered, this, &MainToolBar::onQueue);
+
 	// Media controls
 	previous = createShortcutAction(QStringLiteral("media-skip-backward"),
 		QStringLiteral("Previous"), Shortcut::previousTrack());
@@ -123,6 +129,7 @@ MainToolBar::MainToolBar(lib::spt::api &spotify, lib::settings &settings,
 	if (isSearchMirrored)
 	{
 		addAction(search);
+		addAction(queue);
 	}
 
 	addSeparator();
@@ -142,6 +149,7 @@ MainToolBar::MainToolBar(lib::spt::api &spotify, lib::settings &settings,
 	if (!isSearchMirrored)
 	{
 		addAction(search);
+		addAction(queue);
 	}
 
 	if (!isMirrored)
@@ -515,6 +523,15 @@ void MainToolBar::onClose(bool /*checked*/)
 	else
 	{
 		QCoreApplication::quit();
+	}
+}
+
+void MainToolBar::onQueue(bool /*checked*/)
+{
+	auto *mainWindow = MainWindow::find(parentWidget());
+	if (mainWindow != nullptr)
+	{
+		mainWindow->toggleQueue();
 	}
 }
 

--- a/src/view/maintoolbar.hpp
+++ b/src/view/maintoolbar.hpp
@@ -57,6 +57,7 @@ private:
 	void onRepeat(bool checked);
 	void onMinimize(bool checked);
 	void onClose(bool checked);
+	void onQueue(bool checked);
 
 	void onPlaybackRefreshed(const lib::spt::playback &current,
 		const lib::spt::playback &previousPlayback);
@@ -65,6 +66,7 @@ private:
 
 	QToolButton *menu;
 	QAction *search;
+	QAction *queue;
 
 	QAction *previous;
 	QAction *playPause;

--- a/src/view/queue/CMakeLists.txt
+++ b/src/view/queue/CMakeLists.txt
@@ -1,0 +1,2 @@
+target_sources(${PROJECT_NAME} PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/view.cpp)

--- a/src/view/queue/view.cpp
+++ b/src/view/queue/view.cpp
@@ -1,0 +1,440 @@
+#include "view/queue/view.hpp"
+
+#include "util/icon.hpp"
+#include "lib/log.hpp"
+#include "lib/spotify/util.hpp"
+#include "widget/statusmessage.hpp"
+
+#include <QHeaderView>
+#include <QTimer>
+#include <QStackedWidget>
+#include <QMenu>
+#include <QContextMenuEvent>
+#include <QApplication>
+#include <QClipboard>
+#include <QFont>
+
+Queue::View::View(lib::spt::api &spotify, lib::settings &settings, QWidget *parent)
+	: QDockWidget("Queue", parent),
+	spotify(spotify),
+	settings(settings),
+	isQueueEmpty(true) // Initialize as empty until we know otherwise
+{
+	setObjectName("QueueDock");
+	setAllowedAreas(Qt::AllDockWidgetAreas);
+	setFeatures(QDockWidget::DockWidgetMovable); // Only allow moving, remove close and undock buttons
+	setupUi();
+	startAutoRefresh();
+}
+
+Queue::View::~View()
+{
+	stopAutoRefresh();
+}
+
+void Queue::View::setupUi()
+{
+	// Create central widget for the dock widget
+	auto *centralWidget = new QWidget(this);
+	setWidget(centralWidget);
+	
+	auto *layout = new QVBoxLayout(centralWidget);
+	layout->setContentsMargins(0, 0, 0, 0);
+
+	// Create stacked widget to maintain consistent size
+	stackedWidget = new QStackedWidget(centralWidget);
+	layout->addWidget(stackedWidget);
+
+	// Status label
+	statusLabel = new QLabel(QStringLiteral("Loading queue..."), centralWidget);
+	statusLabel->setAlignment(Qt::AlignCenter);
+	statusLabel->setStyleSheet(QStringLiteral("QLabel { color: gray; padding: 10px; }"));
+	statusLabel->setWordWrap(true);
+
+	// Track list
+	trackList = new QListWidget(centralWidget);
+	trackList->setAlternatingRowColors(true);
+	trackList->setSelectionMode(QAbstractItemView::SingleSelection);
+	trackList->setContextMenuPolicy(Qt::CustomContextMenu);
+
+	// Add both widgets to the stacked widget
+	stackedWidget->addWidget(statusLabel);
+	stackedWidget->addWidget(trackList);
+
+	// Set minimum size to prevent resizing
+	centralWidget->setMinimumWidth(250);
+	centralWidget->setMinimumHeight(300);
+
+	// Set up refresh timer
+	refreshTimer = new QTimer(this);
+	refreshTimer->setSingleShot(false);
+	refreshTimer->setInterval(2000); // Default interval - will be adjusted based on queue state
+
+	// Connect signals
+	QWidget::connect(trackList, &QListWidget::itemClicked,
+		this, &Queue::View::onItemClicked);
+
+	QWidget::connect(trackList, &QListWidget::itemDoubleClicked,
+		this, &Queue::View::onItemDoubleClicked);
+
+	QWidget::connect(trackList, &QListWidget::customContextMenuRequested,
+		this, &Queue::View::onContextMenu);
+
+	QWidget::connect(refreshTimer, &QTimer::timeout,
+		this, &Queue::View::refreshQueue);
+
+	// Start with status message showing
+	showStatusMessage(QStringLiteral("Loading queue..."));
+}
+
+void Queue::View::refreshQueue()
+{
+	// Only show refreshing message if we don't already have content and it's not already showing an empty state
+	// Also avoid showing it if we know the queue is empty to prevent flickering
+	if (trackList->count() == 0 && statusLabel->text() != QStringLiteral("No tracks in queue") && !isQueueEmpty)
+	{
+		showStatusMessage(QStringLiteral("Refreshing queue..."));
+	}
+
+	spotify.queue([this](const lib::result<lib::spt::queue> &result)
+	{
+		if (!result.success())
+		{
+			showStatusMessage(QString::fromStdString(result.message()));
+			return;
+		}
+
+		const auto &queue = result.value();
+		
+		// Store the queue for skip operations
+		currentQueue = queue;
+		
+		// Check if queue is effectively empty (no currently playing and no upcoming tracks)
+		const bool queueEmpty = !queue.currently_playing.is_valid() && queue.tracks.empty();
+		
+		// Adjust refresh interval based on queue state
+		if (queueEmpty != isQueueEmpty)
+		{
+			isQueueEmpty = queueEmpty;
+			if (isQueueEmpty)
+			{
+				// Queue is empty - refresh less frequently to avoid distraction
+				refreshTimer->setInterval(5000); // 5 seconds
+			}
+			else
+			{
+				// Queue has content - refresh more frequently for responsiveness
+				refreshTimer->setInterval(2000); // 2 seconds
+			}
+		}
+		
+		// Always rebuild to ensure we have the latest queue content
+		// The queue content can change even if the count stays the same
+		trackList->clear();
+
+		// Add currently playing track at the top if available
+		if (queue.currently_playing.is_valid())
+		{
+			auto *currentItem = new QListWidgetItem();
+			
+			// Store data for currently playing track (0 skips needed - already playing)
+			currentItem->setData(Qt::UserRole, 0);
+			
+			// Store track name and artist name for format updates
+			currentItem->setData(Qt::UserRole + 1, QString::fromStdString(queue.currently_playing.name));
+			if (!queue.currently_playing.artists.empty())
+			{
+				currentItem->setData(Qt::UserRole + 2, QString::fromStdString(queue.currently_playing.artists.front().name));
+			}
+			
+			// Store track URI
+			currentItem->setData(Qt::UserRole + 3, QString::fromStdString(queue.currently_playing.id));
+			
+			// Mark as currently playing
+			currentItem->setData(Qt::UserRole + 4, true);
+			
+			// Format display text
+			updateItemText(currentItem);
+			
+			// Set play icon for currently playing track
+			currentItem->setIcon(Icon::get(QStringLiteral("media-playback-start")));
+			
+			// Make the text bold to distinguish it
+			QFont font = currentItem->font();
+			font.setBold(true);
+			currentItem->setFont(font);
+			
+			trackList->addItem(currentItem);
+		}
+
+		// Check if queue is empty (no upcoming tracks)
+		if (queue.tracks.empty())
+		{
+			// If we have a currently playing track, show it, otherwise show empty message
+			if (!queue.currently_playing.is_valid())
+			{
+				showStatusMessage(QStringLiteral("No tracks in queue"));
+				return;
+			}
+		}
+
+		// Populate track list with upcoming tracks
+		for (size_t i = 0; i < queue.tracks.size(); i++)
+		{
+			const auto &track = queue.tracks.at(i);
+			auto *item = new QListWidgetItem();
+			
+			// Store the number of skips needed (position + 1)
+			item->setData(Qt::UserRole, static_cast<int>(i + 1));
+			
+			// Store track name and artist name for format updates
+			item->setData(Qt::UserRole + 1, QString::fromStdString(track.name));
+			if (!track.artists.empty())
+			{
+				item->setData(Qt::UserRole + 2, QString::fromStdString(track.artists.front().name));
+			}
+			
+			// Store track URI for removal from queue
+			item->setData(Qt::UserRole + 3, QString::fromStdString(track.id));
+			
+			// Mark as not currently playing
+			item->setData(Qt::UserRole + 4, false);
+			
+			// Format display text
+			updateItemText(item);
+
+			// No icon for upcoming tracks - only the currently playing track has an icon
+			
+			trackList->addItem(item);
+		}
+
+		// Show the track list
+		showTrackList();
+	});
+}
+
+void Queue::View::skipTracks(int skips)
+{
+	if (skips <= 0)
+	{
+		return;
+	}
+
+	// Check if skip index is valid
+	if (static_cast<size_t>(skips - 1) >= currentQueue.tracks.size())
+	{
+		lib::log::error("Skip index {} exceeds queue size {}", skips - 1, currentQueue.tracks.size());
+		return;
+	}
+
+	// Limit maximum skips to prevent excessive API calls
+	const int maxSkips = 15; // Reasonable limit
+	if (skips > maxSkips)
+	{
+		lib::log::warn("Limiting skip operation from {} to {} tracks", skips, maxSkips);
+		StatusMessage::warn(QString("Can only skip up to %1 tracks at once").arg(maxSkips));
+		skips = maxSkips;
+	}
+
+	// Use the next API to skip, but with improved error handling
+	// This preserves the queue context better than play_tracks
+	skipToTrackRecursive(skips, 0);
+}
+
+void Queue::View::skipToTrackRecursive(int totalSkips, int currentSkip)
+{
+	if (currentSkip >= totalSkips)
+	{
+		// We've skipped enough tracks, refresh the queue
+		QTimer::singleShot(800, this, &Queue::View::refreshQueue);
+		return;
+	}
+
+	spotify.next([this, totalSkips, currentSkip](const std::string &result)
+	{
+		if (!result.empty())
+		{
+			lib::log::error("Failed to skip track {}/{}: {}", currentSkip + 1, totalSkips, result);
+			
+			// Show error only on first failure to avoid spam
+			if (currentSkip == 0)
+			{
+				StatusMessage::error(QString("Failed to skip to track: %1")
+					.arg(QString::fromStdString(result)));
+			}
+			
+			// Still try to refresh the queue to show current state
+			QTimer::singleShot(800, this, &Queue::View::refreshQueue);
+			return;
+		}
+
+		// Continue with next skip
+		skipToTrackRecursive(totalSkips, currentSkip + 1);
+	});
+}
+
+void Queue::View::onItemClicked(QListWidgetItem *item)
+{
+	// Single click just selects the item, no action taken
+	Q_UNUSED(item)
+}
+
+void Queue::View::onItemDoubleClicked(QListWidgetItem *item)
+{
+	if (item == nullptr)
+	{
+		return;
+	}
+
+	// Check if this is the currently playing track
+	const bool isCurrentlyPlaying = item->data(Qt::UserRole + 4).toBool();
+	if (isCurrentlyPlaying)
+	{
+		// Don't try to skip to the currently playing track
+		return;
+	}
+
+	const auto skips = item->data(Qt::UserRole).toInt();
+	if (skips > 0)
+	{
+		skipTracks(skips);
+	}
+}
+
+void Queue::View::startAutoRefresh()
+{
+	refreshQueue(); // Initial refresh
+	refreshTimer->start();
+}
+
+void Queue::View::stopAutoRefresh()
+{
+	refreshTimer->stop();
+}
+
+void Queue::View::refreshFormat()
+{
+	// Update formatting of existing items without fetching new data
+	for (int i = 0; i < trackList->count(); ++i)
+	{
+		auto *item = trackList->item(i);
+		if (item != nullptr)
+		{
+			updateItemText(item);
+		}
+	}
+}
+
+void Queue::View::updateItemText(QListWidgetItem *item)
+{
+	if (item == nullptr)
+	{
+		return;
+	}
+
+	const QString songTitle = item->data(Qt::UserRole + 1).toString();
+	const QString artistName = item->data(Qt::UserRole + 2).toString();
+	
+	QString displayText;
+	if (!artistName.isEmpty())
+	{
+		if (settings.general.queue_swap_name_format)
+		{
+			// Artist - Song format
+			displayText = QString("%1 - %2").arg(artistName).arg(songTitle);
+		}
+		else
+		{
+			// Song - Artist format (default)
+			displayText = QString("%1 - %2").arg(songTitle).arg(artistName);
+		}
+	}
+	else
+	{
+		displayText = songTitle;
+	}
+	
+	item->setText(displayText);
+	item->setToolTip(displayText);
+}
+
+void Queue::View::showTrackList()
+{
+	stackedWidget->setCurrentWidget(trackList);
+}
+
+void Queue::View::showStatusMessage(const QString &message)
+{
+	statusLabel->setText(message);
+	stackedWidget->setCurrentWidget(statusLabel);
+}
+
+void Queue::View::onContextMenu(const QPoint &position)
+{
+	auto *item = trackList->itemAt(position);
+	if (item == nullptr)
+	{
+		return;
+	}
+
+	auto *menu = new QMenu(this);
+
+	// Check if this is the currently playing track
+	const bool isCurrentlyPlaying = item->data(Qt::UserRole + 4).toBool();
+	const auto skips = item->data(Qt::UserRole).toInt();
+	const auto trackName = item->data(Qt::UserRole + 1).toString();
+	
+	if (!isCurrentlyPlaying && skips > 0)
+	{
+		// Skip to this track (only for upcoming tracks)
+		auto *skipAction = menu->addAction(Icon::get(QStringLiteral("media-skip-forward")), 
+			QString("Skip to song"));
+
+		QAction::connect(skipAction, &QAction::triggered, [this, skips]()
+		{
+			skipTracks(skips);
+		});
+
+		menu->addSeparator();
+	}
+	else if (isCurrentlyPlaying)
+	{
+		// For currently playing track, show it's playing
+		auto *playingAction = menu->addAction(Icon::get(QStringLiteral("media-playback-start")), 
+			QStringLiteral("Currently Playing"));
+		playingAction->setEnabled(false);
+		
+		menu->addSeparator();
+	}
+
+	// Remove from queue - show that it's not possible
+	auto *removeAction = menu->addAction(Icon::get(QStringLiteral("list-remove")), 
+		QStringLiteral("Remove from queue"));
+	removeAction->setEnabled(false);
+	removeAction->setToolTip(QStringLiteral("Spotify API does not support removing tracks from queue"));
+
+	// Copy track info
+	menu->addSeparator();
+	const auto artistName = item->data(Qt::UserRole + 2).toString();
+	const auto displayName = !artistName.isEmpty() 
+		? QString("%1 - %2").arg(trackName).arg(artistName)
+		: trackName;
+	
+	auto *copyAction = menu->addAction(Icon::get(QStringLiteral("edit-copy")), 
+		QStringLiteral("Copy track name"));
+	
+	QAction::connect(copyAction, &QAction::triggered, [displayName]()
+	{
+		QApplication::clipboard()->setText(displayName);
+		StatusMessage::info(QStringLiteral("Track name copied to clipboard"));
+	});
+
+	menu->popup(trackList->mapToGlobal(position));
+}
+
+void Queue::View::onRemoveFromQueue()
+{
+	// This method exists for interface compatibility but cannot be implemented
+	// because the Spotify Web API does not provide a way to remove tracks from the queue
+	StatusMessage::warn(QStringLiteral("Spotify API does not support removing tracks from queue"));
+}

--- a/src/view/queue/view.hpp
+++ b/src/view/queue/view.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "lib/spotify/api.hpp"
+#include "lib/spotify/queue.hpp"
+#include "lib/result.hpp"
+#include "lib/settings.hpp"
+#include "util/icon.hpp"
+
+#include <QWidget>
+#include <QVBoxLayout>
+#include <QListWidget>
+#include <QLabel>
+#include <QTimer>
+#include <QStackedWidget>
+#include <QLineEdit>
+#include <QDockWidget>
+
+namespace Queue
+{
+	class View: public QDockWidget
+	{
+	Q_OBJECT
+
+	public:
+		View(lib::spt::api &spotify, lib::settings &settings, QWidget *parent);
+		~View() override;
+
+		void refreshQueue();
+		void refreshFormat();
+
+	private:
+		lib::spt::api &spotify;
+		lib::settings &settings;
+		QStackedWidget *stackedWidget = nullptr;
+		QListWidget *trackList = nullptr;
+		QLabel *statusLabel = nullptr;
+		QTimer *refreshTimer = nullptr;
+		lib::spt::queue currentQueue; // Store current queue for skip operations
+		bool isQueueEmpty = true; // Track if queue is empty to adjust refresh rate
+
+		void setupUi();
+		void skipTracks(int skips);
+		void skipToTrackRecursive(int totalSkips, int currentSkip);
+
+		void onItemClicked(QListWidgetItem *item);
+		void onItemDoubleClicked(QListWidgetItem *item);
+		void onContextMenu(const QPoint &position);
+		void onRemoveFromQueue();
+		void startAutoRefresh();
+		void stopAutoRefresh();
+		void showTrackList();
+		void showStatusMessage(const QString &message);
+		void updateItemText(QListWidgetItem *item);
+	};
+}

--- a/src/view/search/view.cpp
+++ b/src/view/search/view.cpp
@@ -34,9 +34,23 @@ Search::View::View(lib::spt::api &spotify, lib::cache &cache, const lib::http_cl
 	tabs->addTab(shows, "Podcasts");
 	tabs->addTab(library, "Library");
 
-	// Start searching when pressing enter
-	QLineEdit::connect(searchBox, &QLineEdit::returnPressed,
-		this, &Search::View::search);
+	// Set up search timer for debounced live search
+	searchTimer = new QTimer(this);
+	searchTimer->setSingleShot(true);
+	searchTimer->setInterval(250); // 500ms delay after user stops typing
+	QTimer::connect(searchTimer, &QTimer::timeout, this, &Search::View::search);
+
+	// Start searching when pressing enter (immediate search)
+	QLineEdit::connect(searchBox, &QLineEdit::returnPressed, [this]()
+	{
+		// Stop timer and search immediately when Enter is pressed
+		searchTimer->stop();
+		search();
+	});
+
+	// Start live search when text changes
+	QLineEdit::connect(searchBox, &QLineEdit::textChanged,
+		this, &Search::View::onSearchTextChanged);
 
 	// Searching in library is a separate request,
 	// so only actually search once requested
@@ -71,6 +85,9 @@ void Search::View::hideEvent(QHideEvent *event)
 
 void Search::View::search()
 {
+	// Stop any pending timer-based search since we're searching now
+	searchTimer->stop();
+
 	// Empty all previous results
 	tracks->clear();
 	artists->clear();
@@ -79,11 +96,11 @@ void Search::View::search()
 	library->clear();
 	shows->clear();
 
-	// Disable search box while searching
-	searchBox->setEnabled(false);
+	// Get current search text
+	const QString currentSearchText = searchBox->text();
 
 	// Save last searched query
-	searchText = searchBox->text();
+	searchText = currentSearchText;
 
 	// Search in library cache until tab is selected
 	library->searchCache(searchText.toStdString());
@@ -91,9 +108,12 @@ void Search::View::search()
 	// Don't actually search if nothing to search on
 	if (searchText.isEmpty())
 	{
-		searchBox->setEnabled(true);
 		return;
 	}
+
+	// Set placeholder to show searching status
+	const QString originalPlaceholder = searchBox->placeholderText();
+	searchBox->setPlaceholderText("Searching...");
 
 	// Check if spotify uri
 	if (searchText.startsWith("spotify:")
@@ -162,7 +182,7 @@ void Search::View::search()
 			}
 
 			tabs->setCurrentIndex(static_cast<int>(i));
-			searchBox->setEnabled(true);
+			searchBox->setPlaceholderText(QString()); // Restore normal placeholder
 		}
 	}
 	else
@@ -214,8 +234,8 @@ void Search::View::resultsLoaded(const lib::spt::search_results &results)
 		shows->add(show);
 	}
 
-	// Search done
-	searchBox->setEnabled(true);
+	// Search done - restore normal placeholder
+	searchBox->setPlaceholderText(QString());
 }
 
 void Search::View::onIndexChanged(int index)
@@ -223,5 +243,34 @@ void Search::View::onIndexChanged(int index)
 	if (static_cast<SearchTab>(index) == SearchTab::Library)
 	{
 		library->search(searchText.toStdString());
+	}
+}
+
+void Search::View::onSearchTextChanged()
+{
+	// Stop any pending search
+	searchTimer->stop();
+	
+	// Get current text
+	const QString currentText = searchBox->text();
+	
+	// If text is empty, clear results immediately
+	if (currentText.isEmpty())
+	{
+		tracks->clear();
+		artists->clear();
+		albums->clear();
+		playlists->clear();
+		library->clear();
+		shows->clear();
+		searchText.clear();
+		return;
+	}
+	
+	// Only start timer for searches with at least 2 characters
+	// This prevents excessive API calls for single characters
+	if (currentText.length() >= 2)
+	{
+		searchTimer->start();
 	}
 }

--- a/src/view/search/view.hpp
+++ b/src/view/search/view.hpp
@@ -18,6 +18,7 @@
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 #include <QVBoxLayout>
+#include <QTimer>
 
 namespace Search
 {
@@ -32,6 +33,7 @@ namespace Search
 	private:
 		QTabWidget *tabs = nullptr;
 		QLineEdit *searchBox = nullptr;
+		QTimer *searchTimer = nullptr; // Timer for debounced search
 		lib::spt::api &spotify;
 		lib::cache &cache;
 		const lib::http_client &httpClient;
@@ -44,6 +46,7 @@ namespace Search
 		Shows *shows = nullptr;
 
 		void search();
+		void onSearchTextChanged(); // Handle live search input
 
 	protected:
 		void showEvent(QShowEvent *event) override;

--- a/src/view/sidepanel/view.cpp
+++ b/src/view/sidepanel/view.cpp
@@ -48,6 +48,35 @@ void SidePanel::View::openLyrics(int lyricsId)
 	view->load(lyricsId);
 }
 
+void SidePanel::View::openQueue()
+{
+	auto *queueView = findTab(SidePanelType::Queue, QString());
+	if (queueView == nullptr)
+	{
+		queueView = new Queue::View(spotify, settings, this);
+		addTab(queueView, "media-track-show-active", "Queue",
+			SidePanelType::Queue, QString());
+	}
+	else
+	{
+		setCurrentWidget(queueView);
+		setVisible(true);
+	}
+}
+
+void SidePanel::View::refreshQueueFormat()
+{
+	auto *queueView = findTab(SidePanelType::Queue, QString());
+	if (queueView != nullptr)
+	{
+		auto *queue = dynamic_cast<Queue::View *>(queueView);
+		if (queue != nullptr)
+		{
+			queue->refreshFormat();
+		}
+	}
+}
+
 void SidePanel::View::openSearch()
 {
 	if (searchView == nullptr)
@@ -82,6 +111,9 @@ auto SidePanel::View::findTab(SidePanelType type, const QString &name) -> QWidge
 
 		case SidePanelType::Lyrics:
 			return find<::View::Lyrics *>(name);
+
+		case SidePanelType::Queue:
+			return find<Queue::View *>(name);
 
 		default:
 			return nullptr;
@@ -150,6 +182,11 @@ void SidePanel::View::setTabText(QWidget *widget, const QString &text)
 
 	const auto tabText = QString(text).replace('&', QStringLiteral("&&"));
 	title->setTabText(index, tabText);
+}
+
+auto SidePanel::View::currentWidget() -> QWidget *
+{
+	return stack->currentWidget();
 }
 
 void SidePanel::View::onTabMoved(int from, int to)

--- a/src/view/sidepanel/view.hpp
+++ b/src/view/sidepanel/view.hpp
@@ -3,6 +3,7 @@
 #include "lib/spotify/track.hpp"
 #include "view/artist/view.hpp"
 #include "view/search/view.hpp"
+#include "view/queue/view.hpp"
 #include "view/lyrics.hpp"
 #include "view/sidepanel/title.hpp"
 #include "enum/sidepaneltype.hpp"
@@ -27,12 +28,18 @@ namespace SidePanel
 		void openSearch();
 		void closeSearch();
 
+		void openQueue();
+
+		void refreshQueueFormat();
+
 		void addTab(QWidget *widget, const QString &icon, const QString &tabTitle,
 			SidePanelType type, const QString &name);
 
 		void removeTab(int index);
 
 		void setTabText(QWidget *widget, const QString &text);
+
+		auto currentWidget() -> QWidget *;
 
 		static auto find(QWidget *widget) -> View *;
 


### PR DESCRIPTION
Hi all, 

I really wanted to have a way to see the queue and interact with it outside of the dropdown menu. I will be 100% honest, about half of this is ollama assisted, I'm not primarily a QT dev so this was mostly for my use. Feel free to decline :P 

Here's a few screenshots:

<img width="1542" height="785" alt="image" src="https://github.com/user-attachments/assets/8d640b4a-c753-4c96-88dc-3bcdb2c02627" />


<img width="617" height="423" alt="image" src="https://github.com/user-attachments/assets/5536bb20-016d-42f0-8d82-42d8bc114e86" />

Features include: 
- It's a dockable widget, I played around with parenting it to the search window but I kind of like being able to move it... I still have that version if y'all want to see
- Skip directly to song in queue by double clicking or right click > skip (Unfortunately I couldn't figure out how to skip directly to the song and preserve the queue, so instead I skip N times to the selected song, preserving the queue. 
- Setting to swap "Song Name - Artist Name" to "Artist Name - Song Name"
- Queue refreshes live when you switch songs 

Edit... forgot to add I also added a live search feature requested in #243