### PR TITLE
Catch JSON parse errors for responses

### DIFF
--- a/lib/src/spotify/api.cpp
+++ b/lib/src/spotify/api.cpp
@@ -24,6 +24,10 @@ auto lib::spt::api::error_message(const std::string &url, const std::string &dat
 			json = nlohmann::json::parse(data);
 		}
 	}
+	catch (const nlohmann::json::parse_error &e)
+	{
+		lib::log::error("{} failed to parse: {}", data, e.what());
+	}
 	catch (const std::exception &e)
 	{
 		lib::log::warn("{} failed: {}", url, e.what());


### PR DESCRIPTION
For some reason, common API requests for seeking/skipping lead to non-JSON responses for me. To prevent crashes, JSON exceptions are caught same way as in `lib::spt::api::get(&url, &callback)`.