### PR TITLE
Jump to track context on double-click (closes #157)

### DIFF
--- a/src/list/tracks.cpp
+++ b/src/list/tracks.cpp
@@ -785,6 +785,10 @@ void List::Tracks::setPlayingTrackItem(QTreeWidgetItem *item)
 	}
 	item->setIcon(0, Icon::get("media-playback-start"));
 	playingTrackItem = item;
+
+	// Scroll to and select the item
+	setCurrentItem(item);
+	scrollToItem(item);
 }
 
 void List::Tracks::setPlayingTrackItem(const std::string &itemId)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4,6 +4,7 @@
 #include "dialog/whatsnew.hpp"
 #include "lib/time.hpp"
 #include "lib/crash/crashhandler.hpp"
+#include "lib/spotify/util.hpp"
 #include "menu/mainmenubar.hpp"
 #include "util/appconfig.hpp"
 #include "util/url.hpp"
@@ -610,6 +611,44 @@ void MainWindow::stopClient()
 	if (spotifyRunner != nullptr){
 		spotifyRunner->deleteLater();
 		spotifyRunner = nullptr;
+	}
+}
+
+void MainWindow::jumpToPlaybackContext()
+{
+	const auto &playbackContext = current.playback.context;
+	const auto &currentTrackId = current.playback.item.id;
+
+	if (playbackContext.type.empty() || playbackContext.uri.empty())
+	{
+		return;
+	}
+
+	const auto contextId = lib::spt::uri_to_id(playbackContext.uri);
+
+	if (playbackContext.type == "album")
+	{
+		loadAlbum(contextId, currentTrackId);
+	}
+	else if (playbackContext.type == "playlist")
+	{
+		spotify.playlist(contextId, [this, currentTrackId](const lib::result<lib::spt::playlist> &result)
+		{
+			if (!result.success())
+			{
+				StatusMessage::error(QString("Failed to load playlist: %1")
+					.arg(QString::fromStdString(result.message())));
+				return;
+			}
+
+			resetLibraryPlaylist();
+			getSongsTree()->load(result.value());
+			getSongsTree()->setPlayingTrackItem(currentTrackId);
+		});
+	}
+	else if (playbackContext.type == "artist")
+	{
+		openArtist(contextId);
 	}
 }
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -69,6 +69,7 @@ public:
 
 	auto startClient() -> const SpotifyClient::Runner *;
 	void stopClient();
+	void jumpToPlaybackContext();
 
 	// Getters for private properties
 	void setSearchChecked(bool checked);

--- a/src/view/context/abstractcontent.cpp
+++ b/src/view/context/abstractcontent.cpp
@@ -1,6 +1,8 @@
 #include "view/context/abstractcontent.hpp"
 #include "mainwindow.hpp"
 
+#include <QMouseEvent>
+
 Context::AbstractContent::AbstractContent(lib::spt::api &spotify, const lib::cache &cache,
 	lib::settings &settings, QWidget *parent)
 	: QWidget(parent),
@@ -72,4 +74,18 @@ void Context::AbstractContent::setCurrentlyPlaying(const lib::spt::track &track)
 auto Context::AbstractContent::isCurrentlyPlaying() const -> bool
 {
 	return isPlaying;
+}
+
+void Context::AbstractContent::mouseDoubleClickEvent(QMouseEvent *event)
+{
+	if (event->button() == Qt::LeftButton)
+	{
+		auto *mainWindow = MainWindow::find(parent());
+		if (mainWindow != nullptr)
+		{
+			mainWindow->jumpToPlaybackContext();
+		}
+	}
+
+	QWidget::mouseDoubleClickEvent(event);
 }

--- a/src/view/context/abstractcontent.hpp
+++ b/src/view/context/abstractcontent.hpp
@@ -40,6 +40,8 @@ namespace Context
 
 		virtual auto iconSize() const -> QSize = 0;
 
+		void mouseDoubleClickEvent(QMouseEvent *event) override;
+
 		template<typename T>
 		auto layout() -> T *
 		{

--- a/src/view/context/titleinfo.cpp
+++ b/src/view/context/titleinfo.cpp
@@ -51,32 +51,9 @@ void Context::TitleInfo::onContextMenu(const QPoint &pos)
 void Context::TitleInfo::onContextMenuTriggered(bool /*checked*/)
 {
 	auto *mainWindow = MainWindow::find(parentWidget());
-	const auto &type = playback.context.type;
-	const auto uri = lib::strings::split(playback.context.uri, ':').back();
-
-	if (type == "album")
+	if (mainWindow != nullptr)
 	{
-		mainWindow->loadAlbum(uri);
-	}
-	else if (type == "artist")
-	{
-		mainWindow->openArtist(uri);
-	}
-	else if (type == "playlist")
-	{
-		spotify.playlist(uri, [mainWindow](const lib::result<lib::spt::playlist> &result)
-		{
-			if (!result.success())
-			{
-				StatusMessage::error(QString("Failed to load playlist: %1")
-					.arg(QString::fromStdString(result.message())));
-
-				return;
-			}
-
-			mainWindow->resetLibraryPlaylist();
-			mainWindow->getSongsTree()->load(result.value());
-		});
+		mainWindow->jumpToPlaybackContext();
 	}
 }
 


### PR DESCRIPTION
Enable double-click on `NowPlaying` widget to navigate back to the playback context (playlist/album/artist) with current track highlighted and scrolled into view.

Move context navigation logic from `TitleInfo` into `MainWindow::jumpToPlaybackContext()` to centralize context and remove duplicate code.

Implement functionality in `AbstractContent` so both `ExpandedContent` and `SmallContent` share the behavior automatically.

Supersedes #293