### PR TITLE
feat: add side panel view for synchronized current track lyrics

### DIFF
--- a/src/enum/sidepaneltype.hpp
+++ b/src/enum/sidepaneltype.hpp
@@ -19,4 +19,9 @@ enum class SidePanelType: char
 	 * Lyrics, paired with track ID
 	 */
 	Lyrics,
+
+	/**
+	 * Current lyrics, synced with playback
+	 */
+	CurrentLyrics,
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -748,6 +748,11 @@ void MainWindow::setSearchChecked(bool checked)
 	toolBar->setSearchChecked(checked);
 }
 
+void MainWindow::setCurrentLyricsChecked(bool checked)
+{
+	toolBar->setCurrentLyricsChecked(checked);
+}
+
 auto MainWindow::getSongsTree() -> List::Tracks *
 {
 	return mainContent->getTracksList();
@@ -787,6 +792,19 @@ void MainWindow::setSearchVisible(bool visible)
 	else
 	{
 		panel->closeSearch();
+	}
+}
+
+void MainWindow::setCurrentLyricsVisible(bool visible)
+{
+	auto *panel = dynamic_cast<SidePanel::View *>(sidePanel);
+	if (visible)
+	{
+		panel->openCurrentLyrics();
+	}
+	else
+	{
+		panel->closeCurrentLyrics();
 	}
 }
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -53,6 +53,7 @@ public:
 	void toggleTrackNumbers(bool enabled);
 	void toggleExpandableAlbum(lib::album_size albumSize);
 	void setSearchVisible(bool visible);
+	void setCurrentLyricsVisible(bool visible);
 	void refreshPlaylists();
 	void setCurrentLibraryItem(QTreeWidgetItem *item);
 	lib::spt::playlist getPlaylist(int index);
@@ -72,6 +73,7 @@ public:
 
 	// Getters for private properties
 	void setSearchChecked(bool checked);
+	void setCurrentLyricsChecked(bool checked);
 	List::Tracks *getSongsTree();
 	const spt::Current &getCurrent();
 	auto getSpotifyRunner() -> const SpotifyClient::Runner *;

--- a/src/view/lyrics.cpp
+++ b/src/view/lyrics.cpp
@@ -45,46 +45,94 @@ View::Lyrics::Lyrics(const HttpClient &httpClient,
 	setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
 	connect(this, &QWidget::customContextMenuRequested,
 		this, &Lyrics::onMenuRequested);
+
+	const auto *window = MainWindow::find(parentWidget());
+	if (window != nullptr)
+	{
+		connect(window, &MainWindow::playbackRefreshed,
+			this, &View::Lyrics::onPlaybackRefreshed);
+	}
+}
+
+void View::Lyrics::setAutoUpdate(bool enabled)
+{
+	autoUpdate = enabled;
+}
+
+auto View::Lyrics::getCurrentTrack() const -> lib::spt::track
+{
+	return currentTrack;
+}
+
+void View::Lyrics::clear()
+{
+	lyricsList->clear();
+	currentTrack = {};
+	currentLyricsId = 0;
+	currentLyricsItem = nullptr;
+	status->setText(QStringLiteral("Nothing playing..."));
+	status->setVisible(true);
 }
 
 void View::Lyrics::open(const lib::spt::track &track)
 {
 	status->setText(QStringLiteral("Please wait..."));
+	status->setVisible(true);
+
+	currentTrack = track;
+	currentLyricsId = 0;
+	currentLyricsItem = nullptr;
 
 	lyrics.get(track, [this, track](const Result<::Lyrics> &result)
 	{
+		if (currentTrack.id != track.id)
+		{
+			return;
+		}
+
 		if (!result.success())
 		{
 			status->setText(result.message());
+			status->setVisible(true);
 			return;
 		}
 
 		status->setVisible(false);
 		load(result.value());
-		currentTrack = track;
 	});
 }
 
 void View::Lyrics::open(const unsigned int lyricsId)
 {
 	status->setText(QStringLiteral("Please wait..."));
+	status->setVisible(true);
 
-	lyrics.get(lyricsId, [this](const Result<::Lyrics> &result)
+	currentTrack = {};
+	currentLyricsId = lyricsId;
+	currentLyricsItem = nullptr;
+
+	lyrics.get(lyricsId, [this, lyricsId](const Result<::Lyrics> &result)
 	{
+		if (currentLyricsId != lyricsId)
+		{
+			return;
+		}
+
 		if (!result.success())
 		{
 			status->setText(result.message());
+			status->setVisible(true);
 			return;
 		}
 
 		status->setVisible(false);
 		load(result.value());
-		currentTrack = {};
 	});
 }
 
 void View::Lyrics::load(const ::Lyrics &loaded)
 {
+	currentLyricsItem = nullptr;
 	lyricsList->clear();
 
 	if (loaded.instrumental())
@@ -124,15 +172,6 @@ void View::Lyrics::load(const ::Lyrics &loaded)
 	{
 		return;
 	}
-
-	const auto *window = MainWindow::find(parentWidget());
-	if (window == nullptr)
-	{
-		return;
-	}
-
-	connect(window, &MainWindow::playbackRefreshed,
-		this, &View::Lyrics::onPlaybackRefreshed);
 }
 
 auto View::Lyrics::getTimestamp(const QListWidgetItem *item) -> qlonglong
@@ -155,6 +194,19 @@ void View::Lyrics::setBold(QListWidgetItem *item, const bool enabled)
 void View::Lyrics::onPlaybackRefreshed(const lib::spt::playback &playback,
 	const lib::spt::playback &/*previous*/)
 {
+	if (autoUpdate && playback.item.id != currentTrack.id)
+	{
+		if (playback.item.is_valid())
+		{
+			open(playback.item);
+		}
+		else
+		{
+			clear();
+		}
+		return;
+	}
+
 	if (!playback.is_playing || lyricsList->count() <= 0)
 	{
 		return;

--- a/src/view/lyrics.hpp
+++ b/src/view/lyrics.hpp
@@ -24,13 +24,20 @@ namespace View
 
 		void open(unsigned int lyricsId);
 
+		void setAutoUpdate(bool enabled);
+		auto getCurrentTrack() const -> lib::spt::track;
+
+		void clear();
+
 	private:
 		static constexpr int timestampRole = 0x100;
+		bool autoUpdate = false;
 		static constexpr float creditsFontScale = 0.9F;
 
 		lib::cache &cache;
 		LyricsApi lyrics;
 		lib::spt::track currentTrack;
+		unsigned int currentLyricsId = 0;
 
 		QLabel *status;
 		QListWidget *lyricsList;

--- a/src/view/maintoolbar.cpp
+++ b/src/view/maintoolbar.cpp
@@ -42,6 +42,12 @@ MainToolBar::MainToolBar(lib::spt::api &spotify, lib::settings &settings,
 	search->setShortcut(QKeySequence::Find);
 	QAction::connect(search, &QAction::triggered, mainWindow, &MainWindow::setSearchVisible);
 
+	// Lyrics
+	currentLyrics = new QAction(Icon::get(QStringLiteral("view-media-lyrics")),
+		QStringLiteral("Current Lyrics"));
+	currentLyrics->setCheckable(true);
+	QAction::connect(currentLyrics, &QAction::triggered, mainWindow, &MainWindow::setCurrentLyricsVisible);
+
 	// Media controls
 	previous = createShortcutAction(QStringLiteral("media-skip-backward"),
 		QStringLiteral("Previous"), Shortcut::previousTrack());
@@ -137,10 +143,17 @@ MainToolBar::MainToolBar(lib::spt::api &spotify, lib::settings &settings,
 
 	addAction(shuffle);
 	addAction(repeat);
+
+	if (isSearchMirrored)
+	{
+		addAction(currentLyrics);
+	}
+
 	addWidget(volumeButton);
 
 	if (!isSearchMirrored)
 	{
+		addAction(currentLyrics);
 		addAction(search);
 	}
 
@@ -318,6 +331,11 @@ void MainToolBar::setShuffle(bool value)
 void MainToolBar::setSearchChecked(bool checked)
 {
 	search->setChecked(checked);
+}
+
+void MainToolBar::setCurrentLyricsChecked(bool checked)
+{
+	currentLyrics->setChecked(checked);
 }
 
 auto MainToolBar::toPosition(Qt::ToolBarArea area) -> lib::position

--- a/src/view/maintoolbar.hpp
+++ b/src/view/maintoolbar.hpp
@@ -29,6 +29,7 @@ public:
 	auto toggleRepeat(const lib::spt::playback &playback) -> lib::repeat_state;
 	void setShuffle(bool shuffle);
 	void setSearchChecked(bool checked);
+	void setCurrentLyricsChecked(bool checked);
 	void toggleActions(const lib::spt::playback &playback);
 
 	static auto toPosition(Qt::ToolBarArea area) -> lib::position;
@@ -64,6 +65,7 @@ private:
 	lib::repeat_state repeatState = lib::repeat_state::off;
 
 	QToolButton *menu;
+	QAction *currentLyrics;
 	QAction *search;
 
 	QAction *previous;

--- a/src/view/sidepanel/view.cpp
+++ b/src/view/sidepanel/view.cpp
@@ -70,6 +70,49 @@ void SidePanel::View::closeSearch()
 	removeTab(stack->indexOf(searchView));
 }
 
+void SidePanel::View::openCurrentLyrics()
+{
+	if (currentLyricsView == nullptr)
+	{
+		auto *view = new ::View::Lyrics(httpClient, cache, this);
+		view->setAutoUpdate(true);
+		currentLyricsView = view;
+	}
+
+	if (stack->indexOf(currentLyricsView) < 0)
+	{
+		addTab(currentLyricsView, "view-media-lyrics", "Current Lyrics",
+			SidePanelType::CurrentLyrics, QString());
+	}
+
+	setCurrentWidget(currentLyricsView);
+	setVisible(true);
+
+	auto *mainWindow = MainWindow::find(this);
+	auto *lyricsView = dynamic_cast<::View::Lyrics *>(currentLyricsView);
+	if (mainWindow != nullptr && lyricsView != nullptr)
+	{
+		mainWindow->setCurrentLyricsChecked(true);
+
+		if (lyricsView->getCurrentTrack().id != mainWindow->playback().item.id)
+		{
+			if (mainWindow->playback().item.is_valid())
+			{
+				lyricsView->open(mainWindow->playback().item);
+			}
+			else
+			{
+				lyricsView->clear();
+			}
+		}
+	}
+}
+
+void SidePanel::View::closeCurrentLyrics()
+{
+	removeTab(stack->indexOf(currentLyricsView));
+}
+
 auto SidePanel::View::findTab(SidePanelType type, const QString &name) -> QWidget *
 {
 	switch (type)
@@ -78,6 +121,9 @@ auto SidePanel::View::findTab(SidePanelType type, const QString &name) -> QWidge
 			return find<Artist::View *>(name);
 
 		case SidePanelType::Search:
+			return nullptr;
+
+		case SidePanelType::CurrentLyrics:
 			return nullptr;
 
 		case SidePanelType::Lyrics:
@@ -114,7 +160,15 @@ void SidePanel::View::removeTab(int index)
 	auto *widget = stack->widget(index);
 	stack->removeWidget(widget);
 
-	if (widget != searchView)
+	if (widget == currentLyricsView)
+	{
+		if (auto *mainWindow = MainWindow::find(this))
+		{
+			mainWindow->setCurrentLyricsChecked(false);
+		}
+	}
+
+	if (widget != searchView && widget != currentLyricsView)
 	{
 		widget->deleteLater();
 	}

--- a/src/view/sidepanel/view.hpp
+++ b/src/view/sidepanel/view.hpp
@@ -27,6 +27,9 @@ namespace SidePanel
 		void openSearch();
 		void closeSearch();
 
+		void openCurrentLyrics();
+		void closeCurrentLyrics();
+
 		void addTab(QWidget *widget, const QString &icon, const QString &tabTitle,
 			SidePanelType type, const QString &name);
 
@@ -44,6 +47,7 @@ namespace SidePanel
 		QStackedWidget *stack = nullptr;
 
 		QWidget *searchView = nullptr;
+		QWidget *currentLyricsView = nullptr;
 
 		lib::spt::api &spotify;
 		lib::settings &settings;


### PR DESCRIPTION
This PR introduces a dedicated "Current Lyrics" view in the side panel that automatically fetches lyrics of the currently playing track.