### PR TITLE
Add option to only refresh when the window is active

### DIFF
--- a/lib/include/lib/settings/general.hpp
+++ b/lib/include/lib/settings/general.hpp
@@ -100,6 +100,11 @@ namespace lib
 			int refresh_interval = 3;
 
 			/**
+			 * Whether to only refresh the window when it's active
+			 */
+			bool refresh_when_active = false;
+
+			/**
 			 * How to resize track list headers
 			 */
 			lib::resize_mode track_list_resize_mode = lib::resize_mode::auto_size;

--- a/lib/src/settings/general.cpp
+++ b/lib/src/settings/general.cpp
@@ -16,6 +16,7 @@ void lib::setting::to_json(nlohmann::json &j, const general &g)
 		{"notify_track_change", g.notify_track_change},
 		{"playlist_order", g.playlist_order},
 		{"refresh_interval", g.refresh_interval},
+		{"refresh_when_active", g.refresh_when_active},
 		{"relative_added", g.relative_added},
 		{"show_changelog", g.show_changelog},
 		{"song_header_sort_by", g.song_header_sort_by},
@@ -53,6 +54,7 @@ void lib::setting::from_json(const nlohmann::json &j, general &g)
 	lib::json::get(j, "notify_track_change", g.notify_track_change);
 	lib::json::get(j, "playlist_order", g.playlist_order);
 	lib::json::get(j, "refresh_interval", g.refresh_interval);
+	lib::json::get(j, "refresh_when_active", g.refresh_when_active);
 	lib::json::get(j, "relative_added", g.relative_added);
 	lib::json::get(j, "show_changelog", g.show_changelog);
 	lib::json::get(j, "song_header_sort_by", g.song_header_sort_by);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -447,9 +447,10 @@ void MainWindow::minimize()
 
 void MainWindow::refresh()
 {
-	if (refreshCount < 0
+	if ((refreshCount < 0
 		|| ++refreshCount >= settings.general.refresh_interval
 		|| current.playback.progress_ms + lib::time::ms_in_sec > current.playback.item.duration)
+		&& (settings.general.refresh_when_active ? this->isActiveWindow() : true))
 	{
 		spotify.current_playback([this](const Result<lib::spt::playback> &result)
 		{

--- a/src/settingspage/application.cpp
+++ b/src/settingspage/application.cpp
@@ -2,6 +2,9 @@
 
 #include "mainwindow.hpp"
 #include "util/font.hpp"
+#include <qcheckbox.h>
+#include <qcoreapplication.h>
+#include <qlabel.h>
 
 SettingsPage::Application::Application(lib::settings &settings, QWidget *parent)
 	: SettingsPage::Base(settings, parent)
@@ -117,6 +120,11 @@ auto SettingsPage::Application::app() -> QWidget *
 	ignoreUnavailableIndex->setChecked(settings.general.ignore_unavailable_index);
 	layout->addWidget(ignoreUnavailableIndex);
 
+	refreshWhenActive = new QCheckBox(QStringLiteral("Only refresh when active"), this);
+	refreshWhenActive->setToolTip(QStringLiteral("Only refresh the playback state when the window is active"));
+	refreshWhenActive->setChecked(settings.general.refresh_when_active);
+	layout->addWidget(refreshWhenActive);
+
 	return Widget::layoutToWidget(layout, this);
 }
 
@@ -229,6 +237,12 @@ auto SettingsPage::Application::saveGeneral() -> bool
 			success = false;
 		}
 		settings.general.refresh_interval = interval;
+	}
+
+	// Refresh when active
+	{
+		auto checked = refreshWhenActive->isChecked();
+		settings.general.refresh_when_active = checked;
 	}
 
 	// Max queue

--- a/src/settingspage/application.cpp
+++ b/src/settingspage/application.cpp
@@ -2,9 +2,6 @@
 
 #include "mainwindow.hpp"
 #include "util/font.hpp"
-#include <qcheckbox.h>
-#include <qcoreapplication.h>
-#include <qlabel.h>
 
 SettingsPage::Application::Application(lib::settings &settings, QWidget *parent)
 	: SettingsPage::Base(settings, parent)

--- a/src/settingspage/application.hpp
+++ b/src/settingspage/application.hpp
@@ -29,6 +29,7 @@ namespace SettingsPage
 		QCheckBox *appHotkeys = nullptr;
 		QCheckBox *appWhatsNew = nullptr;
 		QComboBox *appRefresh = nullptr;
+		QCheckBox *refreshWhenActive = nullptr;
 		QComboBox *appMaxQueue = nullptr;
 		QCheckBox *appUpdates = nullptr;
 		QCheckBox *ignoreUnavailableIndex = nullptr;


### PR DESCRIPTION
Most of the time, I am tabbed out of spotify-qt, and so I don't need the playback state to refresh all the time. This option makes it so that the playback state only refreshes if the window is focused. Can help with preventing #326 since it will refresh way less often.